### PR TITLE
Removing OE22-601b-00 controller to not use sensor data

### DIFF
--- a/twin4build/api/codes/ml_layer/simulator_api.py
+++ b/twin4build/api/codes/ml_layer/simulator_api.py
@@ -9,6 +9,7 @@ import json
 import os
 import sys
 import datetime
+import numpy as np
 import pandas as pd
 
 ###Only for testing before distributing package
@@ -138,9 +139,16 @@ class SimulatorAPI:
             if room_name not in room_names:
                 room_names.append(room_name)
                 simulation_result_dict["rooms"][room_name] = {}
-            #Add the values of all the columns that contain the substring of room_name in the name to the room_name key in the rooms_data dict
-            simulation_result_dict["rooms"][room_name][column_name] = df_output_supply_dampers[column_name].to_list()    
+            # Add the values of all the columns that contain the substring of room_name in the name to the room_name key in the rooms_data dict
+            sub_dict = df_output_supply_dampers[column_name].to_list()
+            #make the sub_dict a list of floats
+            # Check each item in sub_dict
+            sub_dict = [float(x.item()) if isinstance(x, np.ndarray) else float(x) for x in sub_dict]
+            
+            simulation_result_dict["rooms"][room_name][column_name] = sub_dict
         
+
+
         #simulation_result_dict = df_output.to_dict(orient="list")
 
         logger.info("[SimulatorAPI] : Exited from get_ventilation_simulation_result Function")

--- a/twin4build/api/models/VE01_ventilation_model.py
+++ b/twin4build/api/models/VE01_ventilation_model.py
@@ -44,11 +44,19 @@ def model_definition(self):
 
     co2_property_22_601b_00 = tb.Co2()
 
+    """
     co2_controller_22_601b_00 = tb.ClassificationAnnControllerSystem(
         observes=co2_property_22_601b_00,
         room_identifier=0,
         saveSimulationResult=True,
         id="CO2_controller_22_601b_00")
+    """
+    position_controller_property_22_601b_00 = tb.OpeningPosition()
+    co2_controller_sensor_22_601b_00 = tb.SensorSystem(
+        observes=position_controller_property_22_601b_00,
+        saveSimulationResult=True,
+        doUncertaintyAnalysis=False,
+        id="CO2_controller_sensor_22_601b_00")
     
     position_property_22_601b_00 = tb.OpeningPosition()
     damper_position_sensor_22_601b_00 = tb.SensorSystem(
@@ -762,12 +770,12 @@ def model_definition(self):
     """
 
     # Ø22_601b_00
-    self.add_connection(co2_controller_22_601b_00, supply_damper_22_601b_00,
+    self.add_connection(co2_controller_sensor_22_601b_00, supply_damper_22_601b_00,
                             "inputSignal", "damperPosition")
-    self.add_connection(co2_controller_22_601b_00, return_damper_22_601b_00,
+    self.add_connection(co2_controller_sensor_22_601b_00, return_damper_22_601b_00,
                             "inputSignal", "damperPosition")
-    self.add_connection(space_22_601b_00_CO2_sensor, co2_controller_22_601b_00,
-                            "indoorCo2Concentration", "actualValue")
+    #self.add_connection(space_22_601b_00_CO2_sensor, co2_controller_22_601b_00,
+    #                        "indoorCo2Concentration", "actualValue")
     self.add_connection(supply_damper_22_601b_00, damper_position_sensor_22_601b_00,
                             "damperPosition", "damperPosition_22_601b_00")    
 

--- a/twin4build/model/model.py
+++ b/twin4build/model/model.py
@@ -1148,7 +1148,7 @@ class Model:
                 
                 components_ = self.component_dict.keys()
                 #Make it an array of strings
-                components_ = list(components)
+                components_ = list(components_)
                 # find all the components that contain the last part of the component_id, after the first dash
                 
                 #Extract the substring after the first dash
@@ -1166,6 +1166,28 @@ class Model:
                     elif "Damper_position_sensor" in component:
                         damper_position_sensor = self.component_dict[component]
                         damper_position_sensor.df_input = df_damper
+            
+            ## ADDED FOR DAMPER CONTROL of 601b_00, missing data
+
+            oe_601b_00_component = self.component_dict["CO2_controller_sensor_22_601b_00"]
+            #Create a dataframe with timestamps and damper values, the timestamps are between startTime and endTime, with stepSize
+            freq = f"{stepSize}S"
+            df_damper_control = pd.DataFrame({"timestamp": pd.date_range(start=startTime, end=endTime, freq=freq)})
+            #Create a column with the damper values, all set to 1 
+            df_damper_control["damper_position"] = 1
+            
+            df_damper_control = sample_from_df(df_damper_control,
+                        stepSize=stepSize,
+                        start_time=startTime,
+                        end_time=endTime,
+                        resample=True,
+                        clip=True,
+                        tz="Europe/Copenhagen",
+                        preserve_order=True)
+            
+            #Set the df_input of the component to the new dataframe
+            oe_601b_00_component.df_input = df_damper_control
+
         else:
             sensor_inputs = input_dict["inputs_sensor"] #Change naming to be consistent
             schedule_inputs = input_dict["input_schedules"] #Change naming to be consistent


### PR DESCRIPTION
Removed the controller from the room without available sensor data. 
It is now always outputting full opening position.
@avneet006 The input dictionary should not contain any data for "OE22-601B-00" now.