### PR TITLE
Adding schedule fallback when data not available

### DIFF
--- a/twin4build/api/codes/ml_layer/simulator_api.py
+++ b/twin4build/api/codes/ml_layer/simulator_api.py
@@ -197,8 +197,8 @@ class SimulatorAPI:
             logger.info("[run_simulation] : Entered in run_simulation Function")
 
             #load Model
-            model = Model(id="model", saveSimulationResult=True)
-            model.load_model(fcn=model_definition,input_config=input_dict, infer_connections=False)
+            model = Model(id="VE01_model", saveSimulationResult=True)
+            model.load_model(fcn=model_definition,input_config=input_dict, infer_connections=False, do_load_parameters=False)
 
             startTime = datetime.datetime.strptime(input_dict["metadata"]["start_time"], self.time_format)
             endTime = datetime.datetime.strptime(input_dict["metadata"]["end_time"], self.time_format)

--- a/twin4build/api/models/VE01_ventilation_model.py
+++ b/twin4build/api/models/VE01_ventilation_model.py
@@ -991,7 +991,6 @@ def model_definition(self):
     self.add_connection(supply_damper_22_605c_2, damper_position_sensor_22_605c_2,
                             "damperPosition", "damperPosition_22_605c_2")
 
-
     # Total air flow rate sensor
     self.add_connection(supply_damper_22_601b_00, total_airflow_sensor,
                             "airFlowRate", "airFlowRate_22_601b_00")
@@ -1034,6 +1033,7 @@ def model_definition(self):
     self.add_connection(supply_damper_22_605c_2, total_airflow_sensor,
                             "airFlowRate", "airFlowRate_22_605c_2")
     
+
 def get_total_airflow_rate(model, offset=1.56):
     total_airflow_sensor = model.component_dict["Total_AirFlow_sensor"]
     # Assuming total_airflow_sensor.savedOutput[first_key] is a list
@@ -1047,7 +1047,7 @@ def get_total_airflow_rate(model, offset=1.56):
 def request_to_ventilation_api_test():
         try :
             #fetch input data from the file C:\Project\t4b_fork\Twin4Build\twin4build\api\models\ventilation_input_data.json
-            with open(r"C:\Project\t4b_fork\Twin4Build\twin4build\api\models\ventilation_input_data.json") as file:
+            with open(r"C:\Project\t4b_fork\Twin4Build\twin4build\api\models\ventilation_input_data_schedules_all_rooms.json") as file:
                 input_data = json.load(file)
             
 

--- a/twin4build/saref/device/sensor/sensor_system.py
+++ b/twin4build/saref/device/sensor/sensor_system.py
@@ -196,6 +196,7 @@ class SensorSystem(Sensor):
         # self.addUncertainty = addUncertainty
         self._config = {"parameters": [],
                         "readings": {"filename": self.filename,
+                                     "df_input": self.df_input,
                                      "datecolumn": self.datecolumn,
                                      "valuecolumn": self.valuecolumn}
                         }


### PR DESCRIPTION
Changes to the VE01 model.

The model reacts based on the input dictionary flag `sensor_data_available` which should now be added as an extra key value inside each room's sub-dictionary. See attached example input file, where the room `OE22-601B-0` and `OE22-604-0` have schedule values instead of sensor data.

Example input with schedules in two rooms:
[ventilation_input_data_schedules_fallback.json](https://github.com/JBjoernskov/Twin4Build/files/15323755/ventilation_input_data_schedules_fallback.json)
Example input with only schedules:
[ventilation_input_data_schedules_all_rooms.json](https://github.com/JBjoernskov/Twin4Build/files/15323758/ventilation_input_data_schedules_all_rooms.json)


Changes to t4b:
Implemented the method "remove_connection" 
Added df_input as a possible attribute to the SensorSystem class
Deleted a warning which checks if SensorSystem doesn't have a filename, since now it could have a df_input as well.

@avneet006 I haven't tested the model in the whole database interactions since we need to add the flag to the input dictionaries. Let me know if there are any errors when running with the DB.

