### PR TITLE
fix: hard-remove deprecated set_parameters_from_array (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ API-quality major release. Preferred forms are documented below; new soft-compat
 - `plot_component` and legacy `Entry` / tuple plot formats
 - `CascadePIDControllerSystem` alias
 - Estimator legacy `parameters` dict (`private` / `shared`)
+- `set_parameters_from_array` → use `set_parameters`
 - `windows-curses` dependency (curses LOGGER TUI removed)
 
 ### Deprecated (removed in 2.1)

--- a/twin4build/model/model.py
+++ b/twin4build/model/model.py
@@ -595,17 +595,6 @@ class Model:
             save_original=save_original,
         )
 
-    def set_parameters_from_array(self, *args, **kwargs) -> None:
-        """
-        Deprecated: Use set_parameters instead.
-        """
-        warnings.warn(
-            "Method 'set_parameters_from_array' is deprecated. Use 'set_parameters' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.set_parameters(*args, **kwargs)
-
     def restore_parameters(self, keep_values: bool = True) -> None:
         """
         Restore the parameters of the model.

--- a/twin4build/model/simulation_model/simulation_model.py
+++ b/twin4build/model/simulation_model/simulation_model.py
@@ -1458,17 +1458,6 @@ class SimulationModel:
                 else:
                     rsetattr(obj, attr, v)
 
-    def set_parameters_from_array(self, *args, **kwargs) -> None:
-        """
-        Deprecated: Use set_parameters instead.
-        """
-        warnings.warn(
-            "Method 'set_parameters_from_array' is deprecated. Use 'set_parameters' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.set_parameters(*args, **kwargs)
-
     def restore_parameters(self, keep_values: bool = True) -> None:
         """
         Restore parameter objects previously saved by set_parameters
@@ -1835,7 +1824,7 @@ class SimulationModel:
             if cond:
                 self.set_parameters_from_config(entry, component)
             else:
-                self.set_parameters_from_array([entry], [component], [key])
+                self.set_parameters([entry], [component], [key])
         return
 
     def cache(

--- a/twin4build/tests/model/test_model.py
+++ b/twin4build/tests/model/test_model.py
@@ -478,8 +478,8 @@ class TestModelAdvanced(unittest.TestCase):
     def setUp(self):
         self.model = Model(id="test_advanced_model")
 
-    def test_set_parameters_from_array(self):
-        """Test set_parameters_from_array method."""
+    def test_set_parameters(self):
+        """Test set_parameters method."""
         # Local application imports
         from twin4build.systems.damper.damper_system import DamperSystem
 
@@ -487,8 +487,7 @@ class TestModelAdvanced(unittest.TestCase):
         self.model.add_component(damper)
         self.model.load()
 
-        # Set parameter from array
-        self.model.set_parameters_from_array(
+        self.model.set_parameters(
             values=[0.8],
             components=[damper],
             parameter_names=["nominalAirFlowRate"],
@@ -496,7 +495,6 @@ class TestModelAdvanced(unittest.TestCase):
             save_original=True,
         )
 
-        # Check parameter was set
         self.assertAlmostEqual(damper.nominalAirFlowRate.get().item(), 0.8, places=2)
 
     def test_restore_parameters(self):
@@ -508,8 +506,7 @@ class TestModelAdvanced(unittest.TestCase):
         self.model.add_component(damper)
         self.model.load()
 
-        # Save original and set new value
-        self.model.set_parameters_from_array(
+        self.model.set_parameters(
             values=[0.5],
             components=[damper],
             parameter_names=["nominalAirFlowRate"],
@@ -517,7 +514,6 @@ class TestModelAdvanced(unittest.TestCase):
             save_original=True,
         )
 
-        # Restore
         self.model.restore_parameters(keep_values=False)
 
 


### PR DESCRIPTION
## Summary
- Hard-remove `set_parameters_from_array` from `Model` / `SimulationModel` (missed in the 2.0 deprecation sweep in #116).
- Route the remaining internal `set_parameters_from_config` caller through `set_parameters`.
- Update model tests and CHANGELOG `Removed` list.

Closes #94.

## Test plan
- [x] `TestModelAdvanced` (t4bdev)
- [x] CI green