### PR TITLE
docs: branch-aware Colab links + RTD dev version notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 </p>
 
 [![docs](https://app.readthedocs.org/projects/twin4build/badge/?version=latest)](https://twin4build.readthedocs.io/en/latest/)
+[![docs-dev](https://app.readthedocs.org/projects/twin4build/badge/?version=dev)](https://twin4build.readthedocs.io/en/dev/)
 
 
 # twin4build: A python package for Data-driven and Ontology-based modeling and simulation of buildings
@@ -44,36 +45,36 @@ A typical workflow would look like this:
 
 
 ## Examples and Tutorials
-Below are some examples of how to use the package.
-More examples are coming soon.
+Notebooks live in [`twin4build/examples/`](twin4build/examples/) on **this branch** (relative links always open the files from the branch you are viewing on GitHub).
+
+GitHub READMEs cannot parameterize Colab URLs by viewing branch — absolute Colab links are fixed in the file. Prefer the version-matched Colab badges on the docs site:
+
+- [Examples (latest / `main`)](https://twin4build.readthedocs.io/en/latest/manual/examples_and_tutorials.html)
+- [Examples (`dev`)](https://twin4build.readthedocs.io/en/dev/manual/examples_and_tutorials.html)
 
 ### Basics of Twin4Build
-<a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/minimal_example.ipynb">
-  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> Part 1: Connecting components, simulating a model, and visualization<br>
+[minimal_example.ipynb](twin4build/examples/minimal_example.ipynb) — Part 1: Connecting components, simulating a model, and visualization
 
-<a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/space_co2_controller_example.ipynb">
-  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> Part 2: Modeling and control of indoor CO2 concentration<br>
+[space_co2_controller_example.ipynb](twin4build/examples/space_co2_controller_example.ipynb) — Part 2: Modeling and control of indoor CO2 concentration
 
-<a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/bems_example_lecture.ipynb">
-  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> Part 3: Adding a custom System component - RC modeling from scratch of 2 rooms with parameter estimation and heat optimization
+[bems_example_lecture.ipynb](twin4build/examples/bems_example_lecture.ipynb) — Part 3: Adding a custom System component - RC modeling from scratch of 2 rooms with parameter estimation and heat optimization
 
 ### Translator
 
-<a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/translator_example.ipynb">
-  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> Part 1: How to use the translator to generate simulation models from semantic models.
+[translator_example.ipynb](twin4build/examples/translator_example.ipynb) — Part 1: How to use the translator to generate simulation models from semantic models.
 
 ### Estimator
 
-<a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/estimator_example.ipynb">
-  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> Part 1: Basic parameter estimation and calibration
+[estimator_example.ipynb](twin4build/examples/estimator_example.ipynb) — Part 1: Basic parameter estimation and calibration
 
 ### Optimizer
 
-<a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/optimizer_example.ipynb">
-  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> Part 1: Optimization of space heater power consumption, constrained by heating and cooling setpoints.
+[optimizer_example.ipynb](twin4build/examples/optimizer_example.ipynb) — Part 1: Optimization of space heater power consumption, constrained by heating and cooling setpoints.
 
 ## Documentation
-The documentation can be found [online](https://twin4build.readthedocs.io/en/latest/index.html).
+- **Latest (`main`)**: https://twin4build.readthedocs.io/en/latest/
+- **Dev**: https://twin4build.readthedocs.io/en/dev/
+
 Below is a code snippet showing the basic functionality of the package.
 ```python
 import datetime

--- a/docs/clean_sphinx_docs.py
+++ b/docs/clean_sphinx_docs.py
@@ -126,10 +126,19 @@ def remove_module_contents_section(content):
     # First check if this is the main twin4build package file
     if (
         ".. automodule:: twin4build\n" in content
-        and not ".. automodule:: twin4build." in content
+        and ".. automodule:: twin4build." not in content
     ):
         # This is the main twin4build package, change "Module contents" to "Note"
         content = content.replace("Module contents\n---------------", "Note\n----")
+        # Keep only the package docstring here. With a curated ``__all__``,
+        # ``:members:`` dumps the entire public API onto this landing page
+        # (stable docs never did that because the package had no ``__all__``).
+        content = re.sub(
+            r"(\.\. automodule:: twin4build\n)(?:[ ]+:[^\n]*\n)*",
+            r"\1",
+            content,
+            count=1,
+        )
         return content
 
     # For all other modules, remove the Module contents section

--- a/docs/source/auto/twin4build.rst
+++ b/docs/source/auto/twin4build.rst
@@ -22,6 +22,3 @@ Note
 ----
 
 .. automodule:: twin4build
-   :members:
-   :show-inheritance:
-   :undoc-members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -159,24 +159,45 @@ if not show_title_parents:
 
 
 def _github_notebook_branch() -> str:
-    """Branch/tag Colab links should open for this doc build.
+    """Git ref Colab links should open for this doc build.
 
-    On Read the Docs, prefer the git ref being built (branch or tag name).
+    On Read the Docs, prefer a ref GitHub/Colab can resolve (branch, tag, or
+    commit SHA). PR preview builds use version slug ``118`` etc., which is
+    *not* a git ref — those must use the commit hash instead.
     Locally, fall back to the current git branch, then ``dev``.
     """
     rtd_type = os.environ.get("READTHEDOCS_VERSION_TYPE")
     rtd_ident = os.environ.get("READTHEDOCS_GIT_IDENTIFIER")
-    if rtd_type in {"branch", "tag"} and rtd_ident:
+    rtd_version = os.environ.get("READTHEDOCS_VERSION")
+    rtd_commit = os.environ.get("READTHEDOCS_GIT_COMMIT_HASH")
+
+    def _git_head():
+        try:
+            return subprocess.check_output(
+                ["git", "rev-parse", "HEAD"],
+                stderr=subprocess.DEVNULL,
+                text=True,
+            ).strip()
+        except (OSError, subprocess.SubprocessError):
+            return None
+
+    # Pull-request / external builds: VERSION is the PR number, not a branch.
+    if rtd_type == "external":
+        return rtd_commit or _git_head() or "dev"
+
+    if rtd_type in {"branch", "tag"} and rtd_ident and not str(rtd_ident).isdigit():
         return rtd_ident
 
-    # ``latest`` is configured to track ``main`` on this project.
-    rtd_version = os.environ.get("READTHEDOCS_VERSION")
+    # ``latest`` tracks ``main`` on this project.
     if rtd_version == "latest":
         return "main"
     if rtd_version == "stable":
-        return rtd_ident or "main"
-    if rtd_version:
-        # Branch versions use the version slug (e.g. ``dev``).
+        if rtd_ident and not str(rtd_ident).isdigit():
+            return rtd_ident
+        return rtd_commit or "main"
+
+    # Named branch versions (e.g. ``dev``), never numeric PR slugs.
+    if rtd_type == "branch" and rtd_version and not str(rtd_version).isdigit():
         return rtd_version
 
     try:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,6 +8,7 @@
 
 # Standard library imports
 import os
+import subprocess
 import sys
 
 # Add the project root to the Python path
@@ -155,3 +156,53 @@ source_path = "../source/auto"
 # Remove parents from titles in all .rst files
 if not show_title_parents:
     crawl_source_shorten_titles(source_path)
+
+
+def _github_notebook_branch() -> str:
+    """Branch/tag Colab links should open for this doc build.
+
+    On Read the Docs, prefer the git ref being built (branch or tag name).
+    Locally, fall back to the current git branch, then ``dev``.
+    """
+    rtd_type = os.environ.get("READTHEDOCS_VERSION_TYPE")
+    rtd_ident = os.environ.get("READTHEDOCS_GIT_IDENTIFIER")
+    if rtd_type in {"branch", "tag"} and rtd_ident:
+        return rtd_ident
+
+    # ``latest`` is configured to track ``main`` on this project.
+    rtd_version = os.environ.get("READTHEDOCS_VERSION")
+    if rtd_version == "latest":
+        return "main"
+    if rtd_version == "stable":
+        return rtd_ident or "main"
+    if rtd_version:
+        # Branch versions use the version slug (e.g. ``dev``).
+        return rtd_version
+
+    try:
+        branch = subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        if branch and branch != "HEAD":
+            return branch
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return "dev"
+
+
+github_notebook_branch = _github_notebook_branch()
+
+
+def _substitute_github_notebook_branch(app, docname, source):
+    """Expand ``GITHUB_NOTEBOOK_BRANCH`` placeholders in Sphinx sources."""
+    source[0] = source[0].replace(
+        "GITHUB_NOTEBOOK_BRANCH", app.config.github_notebook_branch
+    )
+
+
+def setup(app):
+    app.add_config_value("github_notebook_branch", github_notebook_branch, "env")
+    app.connect("source-read", _substitute_github_notebook_branch)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/source/manual/developer_reference.rst
+++ b/docs/source/manual/developer_reference.rst
@@ -509,6 +509,25 @@ This step compiles all documentation (manual + API) into HTML:
 
 For viewing and browsing the documentation, open the `Twin4Build/build/html/index.html` file in your browser.
 
+**Read the Docs versions**
+
+Published docs:
+
+- ``latest`` → ``main`` → https://twin4build.readthedocs.io/en/latest/
+- ``dev`` → ``dev`` → https://twin4build.readthedocs.io/en/dev/ (activate once in the RTD project)
+
+To make ``dev`` visible (project admins):
+
+1. Open https://app.readthedocs.org/projects/twin4build/versions/
+2. Find the ``dev`` version → **Activate** (and leave it public / not hidden)
+3. Trigger a build for ``dev`` if one does not start automatically
+4. Optional: add an Automation Rule so ``dev`` stays active on future syncs
+
+Colab badges in :doc:`examples_and_tutorials` use the placeholder
+``GITHUB_NOTEBOOK_BRANCH``, which ``docs/source/conf.py`` replaces with the
+git ref for the version being built (so ``/en/dev/`` badges open notebooks
+on ``dev``).
+
 Writing Documentation
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/manual/developer_reference.rst
+++ b/docs/source/manual/developer_reference.rst
@@ -524,9 +524,10 @@ To make ``dev`` visible (project admins):
 4. Optional: add an Automation Rule so ``dev`` stays active on future syncs
 
 Colab badges in :doc:`examples_and_tutorials` use the placeholder
-``GITHUB_NOTEBOOK_BRANCH``, which ``docs/source/conf.py`` replaces with the
-git ref for the version being built (so ``/en/dev/`` badges open notebooks
-on ``dev``).
+``GITHUB_NOTEBOOK_BRANCH``, which ``docs/source/conf.py`` replaces with a
+git ref GitHub/Colab can resolve: branch/tag name for normal versions
+(``/en/dev/`` → ``blob/dev/...``), and the **commit SHA** for pull-request
+previews (RTD's version slug ``118`` is not a git ref).
 
 Writing Documentation
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/manual/examples_and_tutorials.rst
+++ b/docs/source/manual/examples_and_tutorials.rst
@@ -11,58 +11,60 @@ in particular :class:`~twin4build.simulator.simulator.Simulator`,
 :class:`~twin4build.translator.translator.Translator`).
 
 Every notebook can be opened directly in Google Colab (badge links below) or
-run locally in Jupyter.
+run locally in Jupyter. Colab badges are rewritten at docs build time to the
+git branch/tag for this documentation version (e.g. ``dev`` docs open
+``blob/dev/...``, ``latest`` opens ``blob/main/...``).
 
 Basics of Twin4Build
 --------------------
 
 .. raw:: html
 
-   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/minimal_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Minimal example</b>: Connecting components, simulating a model, and visualizing results &mdash; the core mechanics every other example builds on</p>
+   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/GITHUB_NOTEBOOK_BRANCH/twin4build/examples/minimal_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Minimal example</b>: Connecting components, simulating a model, and visualizing results &mdash; the core mechanics every other example builds on</p>
 
 .. raw:: html
 
-   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/building_space_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Building space</b>: The combined thermal + CO2 building space model driven by weather data, occupancy schedules, and ventilation, plus two zones coupled by an energy-conserving partition wall component</p>
+   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/GITHUB_NOTEBOOK_BRANCH/twin4build/examples/building_space_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Building space</b>: The combined thermal + CO2 building space model driven by weather data, occupancy schedules, and ventilation, plus two zones coupled by an energy-conserving partition wall component</p>
 
 .. raw:: html
 
-   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/space_heater_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Space heater</b>: A discretized space heater (radiator) model coupled to a building space and a PID temperature controller</p>
+   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/GITHUB_NOTEBOOK_BRANCH/twin4build/examples/space_heater_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Space heater</b>: A discretized space heater (radiator) model coupled to a building space and a PID temperature controller</p>
 
 .. raw:: html
 
-   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/space_co2_controller_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>CO2 control</b>: Modeling and closed-loop control of indoor CO2 concentration with dampers and a PID controller</p>
+   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/GITHUB_NOTEBOOK_BRANCH/twin4build/examples/space_co2_controller_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>CO2 control</b>: Modeling and closed-loop control of indoor CO2 concentration with dampers and a PID controller</p>
 
 .. raw:: html
 
-   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/bems_example_lecture.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Custom components (lecture)</b>: Adding a custom System component &mdash; RC modeling from scratch of 2 rooms with parameter estimation and heat optimization</p>
+   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/GITHUB_NOTEBOOK_BRANCH/twin4build/examples/bems_example_lecture.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Custom components (lecture)</b>: Adding a custom System component &mdash; RC modeling from scratch of 2 rooms with parameter estimation and heat optimization</p>
 
 Translator
 ----------
 
 .. raw:: html
 
-   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/translator_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Translator</b>: Generating simulation models automatically from semantic (ontology-based) building descriptions via signature pattern matching</p>
+   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/GITHUB_NOTEBOOK_BRANCH/twin4build/examples/translator_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Translator</b>: Generating simulation models automatically from semantic (ontology-based) building descriptions via signature pattern matching</p>
 
 Estimator
 ---------
 
 .. raw:: html
 
-   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/estimator_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Estimator</b>: Parameter estimation and calibration against measured data &mdash; single-shooting and collocation transcriptions, SciPy and CasADi/IPOPT backends, and result interpretation</p>
+   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/GITHUB_NOTEBOOK_BRANCH/twin4build/examples/estimator_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Estimator</b>: Parameter estimation and calibration against measured data &mdash; single-shooting and collocation transcriptions, SciPy and CasADi/IPOPT backends, and result interpretation</p>
 
 Optimizer
 ---------
 
 .. raw:: html
 
-   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/optimizer_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Optimizer</b>: Optimization of space heater power consumption, constrained by heating and cooling setpoints</p>
+   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/GITHUB_NOTEBOOK_BRANCH/twin4build/examples/optimizer_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Optimizer</b>: Optimization of space heater power consumption, constrained by heating and cooling setpoints</p>
 
 Full Workflow
 -------------
 
 .. raw:: html
 
-   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/main/twin4build/examples/full_workflow_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Full workflow</b>: End-to-end pipeline &mdash; translate a semantic model, calibrate parameters with the Estimator, and optimize a control schedule with the Optimizer</p>
+   <p><a target="_blank" href="https://colab.research.google.com/github/JBjoernskov/Twin4Build/blob/GITHUB_NOTEBOOK_BRANCH/twin4build/examples/full_workflow_example.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> <b>Full workflow</b>: End-to-end pipeline &mdash; translate a semantic model, calibrate parameters with the Estimator, and optimize a control schedule with the Optimizer</p>
 
 Running Examples
 ----------------


### PR DESCRIPTION
## Summary
- Sphinx docs replace `GITHUB_NOTEBOOK_BRANCH` at build time so Colab badges open notebooks from the git ref for that doc version (`/en/dev/` ? `blob/dev/...`, `latest` ? `blob/main/...`).
- README: relative notebook links (correct for whatever branch you are viewing on GitHub) + links to latest/dev docs for version-matched Colab badges. GitHub READMEs cannot auto-parameterize absolute Colab URLs.
- Developer reference: steps to **Activate** the RTD `dev` version (required once; `/en/dev/` is currently 404 until that is done).

## Activate RTD `dev` (manual, project admin)
1. https://app.readthedocs.org/projects/twin4build/versions/
2. Activate `dev` (public)
3. Wait for build ? https://twin4build.readthedocs.io/en/dev/

## Test plan
- [x] `conf.py` branch resolver + substitution smoke check
- [ ] After merge + RTD activate: Colab badges on `/en/dev/` point at `blob/dev/...`
- [ ] `/en/latest/` badges still point at `blob/main/...`