### PR TITLE
fix: build blank-node SemanticInstances through __init__ (#144)

### DIFF
--- a/twin4build/model/semantic_model/semantic_model.py
+++ b/twin4build/model/semantic_model/semantic_model.py
@@ -22,7 +22,7 @@ import rdflib.tools.csv2rdf
 import typer
 from bs4 import BeautifulSoup
 from openpyxl import load_workbook
-from rdflib import RDF, RDFS, Graph, Literal, Namespace, URIRef
+from rdflib import RDF, RDFS, BNode, Graph, Literal, Namespace, URIRef
 from rdflib.tools.rdf2dot import rdf2dot
 
 # Local application imports
@@ -97,7 +97,13 @@ class SemanticEntity:
     """
 
     def __init__(self, uri: Union[str, URIRef, Literal], model: "SemanticModel"):
-        self.uri = URIRef(uri) if isinstance(uri, str) else uri
+        # ``BNode`` (and ``URIRef`` / ``Literal``) are ``str`` subclasses, so a
+        # plain ``isinstance(uri, str)`` check would silently re-wrap a blank
+        # node as a ``URIRef`` and break every ``predicate_objects`` lookup on
+        # it.  Only bare strings are promoted to ``URIRef``.
+        if isinstance(uri, str) and not isinstance(uri, (URIRef, BNode, Literal)):
+            uri = URIRef(uri)
+        self.uri = uri
         self.model = model
         self._namespace = (None, None)
 
@@ -2317,18 +2323,18 @@ class SemanticModel:
             else:
                 return SemanticLiteral(value, self, datatype=datatype, lang=lang)
 
-        # Handle BNodes — preserve as BNode so predicate_objects() queries work correctly
+        # Handle BNodes -- keyed separately so a blank node id can never
+        # collide with a URI.  ``SemanticObject.__init__`` preserves the
+        # ``BNode`` type, so the regular constructor is used: an earlier
+        # hand-rolled ``__new__`` initialisation here silently fell out of
+        # sync with ``SemanticInstance.__init__`` (missing
+        # ``_inverse_attributes``), crashing ``get_predicate_subject_pairs``
+        # for any pattern that walks *into* a blank node such as a Brick
+        # ``ref:hasExternalReference`` target.
         if isinstance(value, rdflib.term.BNode):
             bnode_key = f"__bnode__{str(value)}"
             if bnode_key not in self._instances:
-                inst = SemanticInstance.__new__(SemanticInstance)
-                inst.uri = value  # Keep as BNode
-                inst.model = self
-                inst._namespace = (None, None)
-                inst._types = None
-                inst._direct_types = None
-                inst._attributes = None
-                self._instances[bnode_key] = inst
+                self._instances[bnode_key] = SemanticInstance(value, self)
             return self._instances[bnode_key]
 
         # Handle URIs

--- a/twin4build/tests/model/semantic_model/test_semantic_model.py
+++ b/twin4build/tests/model/semantic_model/test_semantic_model.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 
 # Third party imports
-from rdflib import RDF, RDFS, XSD, Graph, Literal, Namespace, URIRef
+from rdflib import RDF, RDFS, XSD, BNode, Graph, Literal, Namespace, URIRef
 
 # Local application imports
 import twin4build
@@ -89,6 +89,45 @@ class TestSemanticModel(unittest.TestCase):
             literal_val, datatype="http://www.w3.org/2001/XMLSchema#string"
         )
         self.assertIsInstance(literal, SemanticLiteral)
+
+    def test_get_instance_bnode_preserves_type_and_inverse_lookup(self):
+        """Blank nodes must be built by the regular constructor (regression).
+
+        ``get_instance`` used to build BNode-backed instances via ``__new__``
+        and hand-initialise a subset of the fields; the ``_inverse_attributes``
+        cache added later was missing, so ``get_predicate_subject_pairs``
+        raised ``AttributeError`` for any blank node -- e.g. the target of a
+        Brick ``ref:hasExternalReference`` -- as soon as the translator walked
+        a pattern backwards into it.
+        """
+        ex = Namespace("http://example.org/")
+        bnode = BNode()
+        self.model.instance_graph.add((ex.sensor, ex.hasExternalReference, bnode))
+        self.model.instance_graph.add((bnode, ex.hasTimeseriesId, Literal("ts-1")))
+
+        inst = self.model.get_instance(bnode)
+        self.assertIsInstance(inst, SemanticInstance)
+        self.assertIsInstance(inst.uri, BNode)
+        self.assertEqual(inst.uri, bnode)
+        self.assertIs(inst, self.model.get_instance(bnode))
+
+        # Outgoing edges still resolve through the blank node.
+        outgoing = inst.get_predicate_object_pairs()
+        self.assertIn(self.model.get_predicate(ex.hasTimeseriesId), outgoing)
+
+        # Incoming edges: this raised AttributeError before the fix.
+        incoming = inst.get_predicate_subject_pairs()
+        pred_in = self.model.get_predicate(ex.hasExternalReference)
+        self.assertIn(pred_in, incoming)
+        self.assertEqual([s.uri for s in incoming[pred_in]], [ex.sensor])
+
+    def test_semantic_object_keeps_bnode_uri(self):
+        """``SemanticObject.__init__`` must not promote a ``BNode`` to ``URIRef``."""
+        bnode = BNode()
+        obj = SemanticObject(bnode, self.model)
+        self.assertIsInstance(obj.uri, BNode)
+        obj2 = SemanticObject("http://example.org/x", self.model)
+        self.assertIsInstance(obj2.uri, URIRef)
 
     def test_get_property(self):
         """Test get_property method."""


### PR DESCRIPTION
Closes #144

## Summary
* `SemanticObject.__init__` no longer re-wraps `URIRef` / `BNode` / `Literal` (all `str` subclasses) as `URIRef`; only bare strings are promoted.
* `SemanticModel.get_instance` builds blank-node instances through the normal `SemanticInstance` constructor instead of a hand-rolled `__new__` path that had fallen out of sync (missing `_inverse_attributes`), so `get_predicate_subject_pairs()` works on blank nodes.

## Test plan
* New `test_get_instance_bnode_preserves_type_and_inverse_lookup` and `test_semantic_object_keeps_bnode_uri` in `test_semantic_model.py` (fail on `dev`, pass here).
* `twin4build/tests/model/semantic_model` + `twin4build/tests/translator` pass (Graphviz-dependent visualize tests excluded on this machine).
* Translating the Hoeje-Taastrup Raadhus Brick graph (blank-node `ref:hasExternalReference` targets) no longer crashes in the leaf-sensor pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
