### PR TITLE
fix: clear error when a time series window is empty (#147)

### DIFF
--- a/twin4build/systems/utils/time_series_input_system.py
+++ b/twin4build/systems/utils/time_series_input_system.py
@@ -420,6 +420,23 @@ class TimeSeriesInputSystem(core.System):
         )  # Before we used nan, but this caused issues with the optimizer when the optimizer tried to compute the gradient of the loss function.
         for batch_index, df in enumerate(self.df):
             size = len(df.index)
+            if size == 0:
+                # Surface the offending sensor instead of the opaque numpy
+                # "could not broadcast input array from shape (0,0)" error
+                # that used to escape from the assignment below.
+                source = (
+                    f"uuid={self.uuid!r}"
+                    if self.uuid is not None
+                    else f"filename={self.filename!r}"
+                    if self.filename is not None
+                    else "df"
+                )
+                raise ValueError(
+                    f'No data for "{self.id}" ({source}) in the window '
+                    f"{start_time[batch_index]} -> {end_time[batch_index]}. "
+                    "Check the timeseries id / table and that the point "
+                    "holds numeric values in that period."
+                )
             # OLD: Only fill actual data, leave rest as 0
             # values[batch_index,:size] = df.values
 

--- a/twin4build/tests/systems/sensor/test_empty_time_series.py
+++ b/twin4build/tests/systems/sensor/test_empty_time_series.py
@@ -1,0 +1,55 @@
+"""A sensor whose database query returns no rows in the simulated window
+must fail with a message naming the sensor, not with numpy's
+``could not broadcast input array from shape (0,0)``."""
+
+# Standard library imports
+import datetime
+import unittest
+from unittest import mock
+from zoneinfo import ZoneInfo
+
+# Third party imports
+import pandas as pd
+
+# Local application imports
+import twin4build
+import twin4build.systems.utils.time_series_input_system as tsi_mod
+from twin4build.systems.sensor.sensor_system import SensorSystem
+
+twin4build._IS_TESTING = True
+
+DBCONFIG = {
+    "table_name": "measurements",
+    "db_host": "localhost",
+    "db_port": 5432,
+    "db_name": "db",
+    "db_user": "u",
+    "db_password": "p",
+}
+
+
+class TestEmptyTimeSeriesError(unittest.TestCase):
+    def test_empty_database_result_raises_named_error(self):
+        tz = ZoneInfo("Europe/Copenhagen")
+        sensor = SensorSystem(
+            id="lonely_sensor", uuid="POINT_WITHOUT_DATA", dbconfig=DBCONFIG
+        )
+        start = datetime.datetime(2024, 3, 4, tzinfo=tz)
+        end = datetime.datetime(2024, 3, 5, tzinfo=tz)
+
+        empty = pd.DataFrame(
+            {"POINT_WITHOUT_DATA": []},
+            index=pd.DatetimeIndex([], tz=tz, name="time"),
+        )
+        with mock.patch.object(tsi_mod, "load_from_database", return_value=empty):
+            with self.assertRaises(ValueError) as ctx:
+                sensor.initialize(
+                    start_time=[start], end_time=[end], step_size=[600]
+                )
+        msg = str(ctx.exception)
+        self.assertIn("lonely_sensor", msg)
+        self.assertIn("POINT_WITHOUT_DATA", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #147

## Summary
`TimeSeriesInputSystem.initialize` raises a `ValueError` that names the sensor id, its `uuid` / `filename` and the requested window when the loaded frame is empty, instead of numpy's `could not broadcast input array from shape (0,0)`.

Example from the HTR case:
```
ValueError: No data for "time series input - outdoorTemperature - [HTR1_VES01_TUD01][HTR9_VES01_SI01]" (uuid='HTR1_VES01_TUD01') in the window 2024-03-04 00:00:00+01:00 -> 2024-03-07 00:00:00+01:00. Check the timeseries id / table and that the point holds numeric values in that period.
```

## Test plan
* New `twin4build/tests/systems/sensor/test_empty_time_series.py` (mocks `load_from_database` to return an empty frame).
* `twin4build/tests/systems/sensor` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
