### PR TITLE
fix: keep fan and heat-recovery outputs finite at zero flow (#156)

### DIFF
--- a/twin4build/systems/air_to_air_heat_recovery/air_to_air_heat_recovery_system.py
+++ b/twin4build/systems/air_to_air_heat_recovery/air_to_air_heat_recovery_system.py
@@ -296,10 +296,16 @@ class AirToAirHeatRecoverySystem(core.System):
         C_exh = secondary_flow * constants.CP_AIR
         C_min = torch.min(C_sup, C_exh)
 
+        # Zero flow on either side (dampers closed, unit off) is a normal
+        # state handled by ``has_flow`` above; the capacity ratios are
+        # clamped so the (discarded) heat-recovery branch stays finite.
+        C_sup_safe = torch.clamp(C_sup, min=1e-9 * constants.CP_AIR)
+        C_exh_safe = torch.clamp(C_exh, min=1e-9 * constants.CP_AIR)
+
         # Calculate primary temperature out with heat recovery
         primary_temp_out_hr = primary_temp_in + eps_op * (
             secondary_temp_in - primary_temp_in
-        ) * (C_min / C_sup)
+        ) * (C_min / C_sup_safe)
 
         # Clamp to setpoint based on operation mode
         # In heating mode: clamp if output > setpoint
@@ -318,7 +324,7 @@ class AirToAirHeatRecoverySystem(core.System):
 
         # Calculate secondary temperature out using energy conservation
         primary_delta_T = primary_temp_out_hr - primary_temp_in
-        secondary_delta_T = primary_delta_T * (C_sup / C_exh)
+        secondary_delta_T = primary_delta_T * (C_sup / C_exh_safe)
         secondary_temp_out_hr = secondary_temp_in - secondary_delta_T
 
         # Select final outputs: heat recovery values if conditions met, else pass-through

--- a/twin4build/systems/fan/fan_system.py
+++ b/twin4build/systems/fan/fan_system.py
@@ -260,8 +260,17 @@ class FanSystem(core.System, nn.Module):
             + params["c4"] * m_norm**3
         )
 
-        # Calculate temperature rise
-        delta_T = (power * params["f_total"]) / (m_dot * constants.CP_AIR)
+        # Calculate temperature rise.  Zero flow (dampers closed, fan off)
+        # is a normal state: guard the division so the outlet temperature
+        # stays finite (no air moves, so no heating of the air).
+        tol = 1e-9
+        has_flow = m_dot > tol
+        delta_T = torch.where(
+            has_flow,
+            (power * params["f_total"])
+            / (torch.clamp(m_dot, min=tol) * constants.CP_AIR),
+            torch.zeros_like(m_dot),
+        )
         outlet_temp = inlet_temp + delta_T
         return x, {"outletAirTemperature": outlet_temp, "Power": power}
 

--- a/twin4build/tests/systems/fan/test_fan_system.py
+++ b/twin4build/tests/systems/fan/test_fan_system.py
@@ -1,5 +1,6 @@
 # Standard library imports
 import datetime
+import math
 import unittest
 
 # Third party imports
@@ -62,6 +63,23 @@ class TestFanTorchSystem(unittest.TestCase):
         self.assertIsNotNone(self.fan.output["Power"].get())
         self.assertGreater(self.fan.output["outletAirTemperature"].get().item(), 20.0)
         self.assertGreater(self.fan.output["Power"].get().item(), 0.0)
+
+    def test_zero_flow_keeps_outlet_finite(self):
+        """Dampers closed / fan off (zero flow) is a normal state: the outlet
+        temperature must equal the inlet temperature, not NaN from the
+        ``P * f / (m * cp)`` temperature-rise term (regression: an AHU fed
+        by closed VAV dampers at night produced a NaN supply temperature)."""
+        start_time = [datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=tz.UTC)]
+        end_time = [datetime.datetime(2023, 1, 1, 1, 40, 0, tzinfo=tz.UTC)]
+        self.fan.initialize(start_time=start_time, end_time=end_time, step_size=[600])
+        self.fan.input["airFlowRate"].set(torch.tensor([0.0]), i_t=0)
+        self.fan.input["inletAirTemperature"].set(torch.tensor([20.0]), i_t=0)
+        datetime_val = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=tz.UTC)
+        self.fan.do_step(second_time=0, date_time=datetime_val, step_size=600, step_index=0)
+        outlet = self.fan.output["outletAirTemperature"].get().item()
+        self.assertTrue(math.isfinite(outlet))
+        self.assertAlmostEqual(outlet, 20.0)
+        self.assertAlmostEqual(self.fan.output["Power"].get().item(), 0.0)
 
     def test_do_step_batch(self):
         """Test fan system do_step method with batch size > 1."""


### PR DESCRIPTION
Closes #156

## Summary
Zero air flow (all VAV dampers closed at night, unit off) is a normal AHU state, but
* `FanSystem.forward` computed the temperature rise as `P·f/(m·cp)` → `0/0 = NaN`;
* `AirToAirHeatRecoverySystem.forward` left the capacity ratios `C_min/C_sup`, `C_sup/C_exh` unguarded.

The fan now applies the rise only where `m > tol` (no flow, no heating of the air), and the heat-recovery ratios are clamped (the existing `has_flow` pass-through selection is unchanged).

## Test plan
* New `test_zero_flow_keeps_outlet_finite` in `test_fan_system.py`: zero flow → outlet equals inlet, power 0 (fails on `dev` with NaN).
* `tests/systems/fan` and `tests/systems/air_to_air_heat_recovery` pass.
* The HTR closed-loop Stage 2 model (identified PI loops closing the dampers at 00:00) no longer aborts with a NaN supply temperature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
