### PR TITLE
fix: stand-alone NoStepRule veto and hub-leak in the pattern walker (#155)

### DIFF
--- a/twin4build/tests/translator/test_walker_veto_and_hub_leak.py
+++ b/twin4build/tests/translator/test_walker_veto_and_hub_leak.py
@@ -1,0 +1,155 @@
+"""Two matcher regressions found on the Hoeje-Taastrup Raadhus graph.
+
+1. A stand-alone :class:`NoStepRule` (not ``&``-composed with a positive
+   rule) pruned every branch: with the predicate absent the walker hit the
+   "missing predicate" prune, with the predicate present but no forbidden
+   neighbour it hit the "no pair matched" prune.  The veto only ever worked
+   inside ``AnyPathRule & NoStepRule``.
+
+2. Bindings leaked between sibling matches through a shared hub: seeded at
+   room R01 the walker crossed ``R01 -> VAV -> AHU -> VAV -> R02`` and
+   carried R02's downstream literals (``brick:volume`` value) back into
+   R01's map, producing one component per room *per* literal.
+"""
+
+# Standard library imports
+import unittest
+
+# Third party imports
+from rdflib import RDF, BNode, Literal, Namespace
+
+# Local application imports
+import twin4build
+import twin4build.core as core
+from twin4build.model.semantic_model.semantic_model import SemanticModel
+from twin4build.systems.building_space.building_space_system import (
+    BuildingSpaceSystem,
+)
+from twin4build.translator.translator import (
+    Node,
+    NoStepRule,
+    Predicate,
+    SignaturePattern,
+    StepRule,
+    Translator,
+)
+
+twin4build._IS_TESTING = True
+
+BRICK = core.namespace.BRICK
+REC = core.namespace.REC
+EX = Namespace("http://example.org/walker#")
+
+
+def _graph(sm, reheat_room=None):
+    g = sm.instance_graph
+    g.add((EX.AHU01, RDF.type, BRICK.AHU))
+    for i in (1, 2):
+        room, vav = EX[f"R0{i}"], EX[f"R0{i}_VAV"]
+        g.add((room, RDF.type, REC.Room))
+        g.add((vav, RDF.type, BRICK.VAV))
+        g.add((EX.AHU01, BRICK.feeds, vav))
+        g.add((vav, BRICK.feeds, room))
+        g.add((vav, BRICK.hasPoint, EX[f"R0{i}_CMD"]))
+        g.add((EX[f"R0{i}_CMD"], RDF.type, BRICK.Damper_Position_Command))
+        vol = BNode()
+        g.add((room, BRICK.volume, vol))
+        g.add((vol, BRICK.value, Literal(20.0 + i)))
+        if reheat_room == i:
+            g.add((vav, BRICK.hasPoint, EX[f"R0{i}_REHEAT"]))
+            g.add((EX[f"R0{i}_REHEAT"], RDF.type, BRICK.Reheat_Command))
+
+
+def _pattern(veto_part=False, veto_point=False, with_volume=False):
+    ahu = Node(cls=BRICK.AHU)
+    vav = Node(cls=BRICK.VAV)
+    space = Node(cls=(REC.Room,))
+    feeds = Predicate((BRICK.feeds,))
+    sp = SignaturePattern(id=f"walker_probe_{veto_part}_{veto_point}_{with_volume}")
+    sp.add_rule(StepRule(subject=ahu, object=vav, predicate=feeds))
+    sp.add_rule(StepRule(subject=vav, object=space, predicate=feeds))
+    if veto_part:
+        sp.add_rule(
+            NoStepRule(
+                subject=vav,
+                object=Node(cls=(BRICK.Heating_Coil, BRICK.Cooling_Coil)),
+                predicate=BRICK.hasPart,
+            )
+        )
+    if veto_point:
+        sp.add_rule(
+            NoStepRule(
+                subject=vav,
+                object=Node(cls=(BRICK.Reheat_Command, BRICK.Valve_Command)),
+                predicate=BRICK.hasPoint,
+            )
+        )
+    if with_volume:
+        vol = Node(cls=(core.BlankNode,))
+        val = Node(cls=(core.namespace.XSD.float, core.namespace.XSD.double, core.namespace.XSD.decimal))
+        sp.add_rule(StepRule(subject=space, object=vol, predicate=BRICK.volume))
+        sp.add_rule(StepRule(subject=vol, object=val, predicate=BRICK.value))
+        sp.add_parameter("mass.V", val)
+        sp.add_modeled_node(vol)
+    sp.add_connection(ahu, "supplyAirTemperature", "supplyAirTemperature")
+    sp.add_modeled_node(space)
+    return sp, space
+
+
+class TestStandaloneNoStepRule(unittest.TestCase):
+    def _complete(self, sp, sm):
+        complete, _ = Translator._match_patterns([BuildingSpaceSystem], sm)
+        return complete[BuildingSpaceSystem].get(sp, [])
+
+    def setUp(self):
+        self._saved_sp = list(BuildingSpaceSystem.sp)
+
+    def tearDown(self):
+        BuildingSpaceSystem.sp = self._saved_sp
+
+    def test_veto_passes_when_predicate_absent(self):
+        sm = SemanticModel(id="veto_absent", namespaces={"ex": str(EX)})
+        _graph(sm)
+        sp, _ = _pattern(veto_part=True)  # no VAV has hasPart at all
+        BuildingSpaceSystem.sp = [sp]
+        self.assertEqual(len(self._complete(sp, sm)), 2)
+
+    def test_veto_passes_when_only_allowed_neighbours(self):
+        sm = SemanticModel(id="veto_allowed", namespaces={"ex": str(EX)})
+        _graph(sm)
+        sp, _ = _pattern(veto_point=True)  # hasPoint exists, but no reheat cmd
+        BuildingSpaceSystem.sp = [sp]
+        self.assertEqual(len(self._complete(sp, sm)), 2)
+
+    def test_veto_prunes_forbidden_neighbour(self):
+        sm = SemanticModel(id="veto_fires", namespaces={"ex": str(EX)})
+        _graph(sm, reheat_room=2)
+        sp, space = _pattern(veto_point=True)
+        BuildingSpaceSystem.sp = [sp]
+        groups = self._complete(sp, sm)
+        self.assertEqual([str(g[space].uri).split("#")[-1] for g in groups], ["R01"])
+
+
+class TestHubLeak(unittest.TestCase):
+    def setUp(self):
+        self._saved_sp = list(BuildingSpaceSystem.sp)
+
+    def tearDown(self):
+        BuildingSpaceSystem.sp = self._saved_sp
+
+    def test_literal_stays_with_its_room(self):
+        sm = SemanticModel(id="hub_leak", namespaces={"ex": str(EX)})
+        _graph(sm)
+        sp, space = _pattern(with_volume=True)
+        BuildingSpaceSystem.sp = [sp]
+        complete, _ = Translator._match_patterns([BuildingSpaceSystem], sm)
+        groups = complete[BuildingSpaceSystem][sp]
+        # One match per room, each carrying its own volume literal.
+        self.assertEqual(len(groups), 2)
+        val_node = sp.parameters["mass.V"]
+        bound = {str(g[space].uri).split("#")[-1]: float(g[val_node].uri) for g in groups}
+        self.assertEqual(bound, {"R01": 21.0, "R02": 22.0})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/twin4build/translator/translator.py
+++ b/twin4build/translator/translator.py
@@ -572,8 +572,15 @@ class Translator:
 
                 for sm_node in candidate_sm_nodes:
 
-                    # Initialize tracking structures for this DFS traversal
+                    # Initialize tracking structures for this DFS traversal.
+                    # The seed binding is recorded up front: otherwise the
+                    # seed stays unbound while its neighbourhood is
+                    # explored, a backward hop (room -> its VAVs) can bind
+                    # the seed's SP node to a *sibling* first, and the
+                    # seed's own descendants are then rejected as binding
+                    # conflicts (one match per room instead of one per VAV).
                     initial_map = {n: None for n in signature_pattern.nodes}
+                    initial_map[sp_node] = sm_node
                     feasible = {n: set() for n in signature_pattern.nodes}
                     comparison_table = {n: set() for n in signature_pattern.nodes}
                     candidate_maps = [Translator._copy_nodemap(initial_map)]

--- a/twin4build/translator/translator.py
+++ b/twin4build/translator/translator.py
@@ -2450,6 +2450,28 @@ class Translator:
         LOGGER.ok("Connecting components", change_status=True)
 
     @staticmethod
+    def _binding_compatible(bound: Any, sm_node: Any) -> bool:
+        """``sm_node`` may extend a map whose slot is unbound, bound to the
+        same node, or set-bound to a tuple containing it."""
+        if bound is None:
+            return True
+        if isinstance(bound, tuple):
+            return sm_node in bound or bound == sm_node
+        return bound == sm_node
+
+    @staticmethod
+    def _cached_descendants_consistent(
+        current_map: Dict[Node, Any], cached: Dict[Node, Any]
+    ) -> bool:
+        """True iff ``cached`` agrees with ``current_map`` on every node the
+        latter has already bound (see the descendant-cache back-fill)."""
+        for sp_n, sm_n in cached.items():
+            bound = current_map.get(sp_n)
+            if bound is not None and bound != sm_n:
+                return False
+        return True
+
+    @staticmethod
     def _copy_nodemap(nodemap: Dict[Node, Any]) -> Dict[Node, Any]:
         return {k: v for k, v in nodemap.items()}
 
@@ -2855,6 +2877,32 @@ class Translator:
         LOGGER.debug("Entering prune_recursive (bidirectional)")
         LOGGER.add_level()
         LOGGER.debug(lambda: Translator._get_node_string(sp_subject, sm_subject))
+        _diag_walker = _match_diag_enabled(signature_pattern)
+
+        # Binding-consistency guard.  A candidate map that already binds
+        # ``sp_subject`` to a *different* SM node cannot be extended through
+        # this SM node: the walker would otherwise carry the descendants of
+        # a sibling match back up through a shared hub (one AHU feeding
+        # several rooms) and, when the hub level re-assigns ``sp_subject``,
+        # leave those foreign descendants in the map -- e.g. room R01
+        # ending up with room R02's ``brick:volume`` literal.
+        consistent_maps = [
+            m
+            for m in candidate_maps
+            if Translator._binding_compatible(m.get(sp_subject), sm_subject)
+        ]
+        if candidate_maps and not consistent_maps:
+            if _diag_walker:
+                _match_diag_write(
+                    f"[WALKER]   PRUNE reason=binding-conflict "
+                    f"pattern={signature_pattern.id} "
+                    f"sp_subject={sp_subject.id} "
+                    f"sm_subject={_diag_sm_name(sm_subject)}"
+                )
+            LOGGER.debug("Pruned (binding conflict)")
+            LOGGER.remove_level()
+            return candidate_maps, feasible, comparison_table, True
+        candidate_maps = consistent_maps
 
         feasible.setdefault(sp_subject, set()).add(sm_subject)
         comparison_table.setdefault(sp_subject, set()).add(sm_subject)
@@ -2960,6 +3008,40 @@ class Translator:
                     sm_neighbors = [
                         x for x in sm_neighbors if not (x in seen or seen.add(x))
                     ]
+
+                    if isinstance(rule, NoStepRule):
+                        # Stand-alone veto: the branch survives iff *no*
+                        # adjacent SM node under the predicate is of the
+                        # forbidden class (an absent predicate trivially
+                        # satisfies the veto).  Nothing is bound.  Before
+                        # this special case the generic "no pair matched /
+                        # missing predicate" pruning below killed every
+                        # branch carrying a stand-alone ``NoStepRule``, so
+                        # the veto only ever worked inside the ``&``
+                        # composite with a positive rule.
+                        far_node = direction.far(rule)
+                        forbidden = [
+                            x for x in sm_neighbors if x.isinstance(far_node.cls)
+                        ]
+                        if forbidden:
+                            feasible[sp_subject].discard(sm_subject)
+                            LOGGER.debug(
+                                "Pruned (NoStepRule veto) [%s]: %s",
+                                direction.name,
+                                Translator._binding_short_name(forbidden[0]),
+                            )
+                            if _diag_walker:
+                                _match_diag_write(
+                                    f"[WALKER]   PRUNE dir={direction.name} "
+                                    f"reason=veto "
+                                    f"pattern={signature_pattern.id} "
+                                    f"sp_subject={sp_subject.id} "
+                                    f"sp_neighbor={sp_neighbor.id} "
+                                    f"sm_subject={_diag_sm_name(sm_subject)}"
+                                )
+                            LOGGER.remove_level()
+                            return candidate_maps, feasible, comparison_table, True
+                        continue
 
                     if sm_neighbors:
                         rule_pairs, _, _, ruleset = rule.apply(
@@ -3082,9 +3164,19 @@ class Translator:
                                 )
                                 for m in maps_for_pair:
                                     m[matched_sp_object] = matched_sm_object
-                                    for sp_n, sm_n in cached.items():
-                                        if m.get(sp_n) is None:
-                                            m[sp_n] = sm_n
+                                    # Cached descendants were derived under
+                                    # the bindings of an earlier branch;
+                                    # only back-fill when they agree with
+                                    # every node this branch has already
+                                    # bound.  Without the check a hub node
+                                    # (e.g. one AHU feeding many rooms)
+                                    # leaks one room's downstream literals
+                                    # (``brick:volume`` value, ...) into
+                                    # the maps of its siblings.
+                                    if Translator._cached_descendants_consistent(m, cached):
+                                        for sp_n, sm_n in cached.items():
+                                            if m.get(sp_n) is None:
+                                                m[sp_n] = sm_n
                                 valid_maps.extend(maps_for_pair)
                                 match_found = True
 
@@ -3398,9 +3490,11 @@ class Translator:
                             )
                             for m in maps_for_pair:
                                 m[matched_sp_object] = matched_sm_object
-                                for sp_n, sm_n in cached.items():
-                                    if m.get(sp_n) is None:
-                                        m[sp_n] = sm_n
+                                # See the matching guard in __prune_recursive.
+                                if Translator._cached_descendants_consistent(m, cached):
+                                    for sp_n, sm_n in cached.items():
+                                        if m.get(sp_n) is None:
+                                            m[sp_n] = sm_n
                             valid_maps.extend(maps_for_pair)
                             match_found = True
 


### PR DESCRIPTION
Closes #155

Stacked on #149 (the tests use blank nodes); base is that branch so the diff shows only this change.

## Summary
Two fixes in `Translator.__prune_recursive`:

1. **Stand-alone `NoStepRule`**: evaluated directly by the walker — the branch is pruned iff an adjacent SM node of the forbidden class exists under the predicate; an absent predicate passes; nothing is bound. Before, the generic "no pair matched" / "missing predicate" pruning killed every branch carrying a stand-alone veto, so `NoStepRule` only worked inside the `AnyPathRule & NoStepRule` composite.
2. **Hub leak**: a candidate map that already binds the SP node to a *different* SM node is no longer extended through the current SM node (`_binding_compatible`), and descendant-cache back-fill only applies when the cached bindings agree with the current map (`_cached_descendants_consistent`). Before, a walk seeded at room R01 crossed `R01 → VAV → AHU → VAV → R02` and brought R02's downstream literals back into R01's map (one match per room *per* literal, wrong `brick:volume` per room).

Both are guarded at the walker level; `NoStepRule.apply` and the composite path are untouched.

## Test plan
* New `tests/translator/test_walker_veto_and_hub_leak.py`: veto passes with absent predicate, passes with only allowed neighbours, prunes with a forbidden neighbour; the volume literal stays with its own room (all fail on `dev`).
* `tests/translator` (incl. `test_offline_translation.py`, `test_translator.py`) and `tests/model/semantic_model` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
