### PR TITLE
feat: per-feed transformation dispatch for OutdoorEnvironmentSystem (#157)

### DIFF
--- a/twin4build/model/model.py
+++ b/twin4build/model/model.py
@@ -723,20 +723,12 @@ class Model:
                 return False
             return any(str(sc.uri) == str(b.uri) for sc in a.super_classes)
 
-        for component in self._simulation_model.components.values():
-            setter = getattr(component, "set_transformation", None)
-            if not callable(setter):
-                continue
-            semantic_nodes = sim2sem.get(component)
-            if not semantic_nodes:
-                continue
-
-            # Gather every rule that matches at least one of the
-            # component's semantic counterparts.
+        def _winner(nodes, component_id):
+            """Most-specific rule matching any of ``nodes`` (first-declared on ties)."""
             matched: List[Tuple[Any, Callable[[Any], Any], Any]] = []
             for stype, fn, original_key in rules:
                 hit = False
-                for node in semantic_nodes:
+                for node in nodes:
                     isinstance_check = getattr(node, "isinstance", None)
                     if callable(isinstance_check) and isinstance_check(
                         stype.uri
@@ -745,11 +737,8 @@ class Model:
                         break
                 if hit:
                     matched.append((stype, fn, original_key))
-
             if not matched:
-                continue
-
-            # Most-specific wins; first-declared on ties.
+                return None
             winner = matched[0]
             for cand in matched[1:]:
                 if _is_strict_subclass(cand[0], winner[0]):
@@ -760,11 +749,35 @@ class Model:
                     warnings.warn(
                         f"set_transformations: rules for {cand[2]!r} and "
                         f"{winner[2]!r} both match component "
-                        f"{component.id!r} with no subclass relationship; "
+                        f"{component_id!r} with no subclass relationship; "
                         f"keeping the first-declared rule ({winner[2]!r}).",
                         stacklevel=2,
                     )
-            setter(winner[1])
+            return winner
+
+        for component in self._simulation_model.components.values():
+            semantic_nodes = sim2sem.get(component)
+            if not semantic_nodes:
+                continue
+            typed_setter = getattr(component, "set_transformation_by_type", None)
+            if callable(typed_setter):
+                # Components that model several semantic nodes with
+                # different roles (an OutdoorEnvironmentSystem models an
+                # outdoor temperature sensor AND a solar irradiance sensor)
+                # get one rule per node, keyed by the class that won for
+                # that node, so a Temperature_Sensor rule and a
+                # Solar_Irradiance_Sensor rule reach their own feeds.
+                for node in semantic_nodes:
+                    winner = _winner([node], component.id)
+                    if winner is not None:
+                        typed_setter(winner[0], winner[1])
+                continue
+            setter = getattr(component, "set_transformation", None)
+            if not callable(setter):
+                continue
+            winner = _winner(semantic_nodes, component.id)
+            if winner is not None:
+                setter(winner[1])
 
         return self
 

--- a/twin4build/systems/outdoor_environment/outdoor_environment_system.py
+++ b/twin4build/systems/outdoor_environment/outdoor_environment_system.py
@@ -215,6 +215,7 @@ class OutdoorEnvironmentSystem(core.System, nn.Module):
         # add a dedicated entry in :data:`TRANSFORMATIONS` and extend
         # this hook with feed-specific setters.
         self._transformation_outdoorTemperature = None
+        self._transformation_globalIrradiation = None
         self.cached_initialize_arguments = []
         self.cache_root = get_main_dir()
 
@@ -594,6 +595,7 @@ class OutdoorEnvironmentSystem(core.System, nn.Module):
                 use_database=self.use_database,
                 uuid=self.uuid_globalIrradiation,
                 dbconfig=self.dbconfig_globalIrradiation,
+                transformation=self._transformation_globalIrradiation,
                 # cache=False,
             )
             time_series_irrad.initialize(start_time, end_time, step_size)
@@ -728,6 +730,29 @@ class OutdoorEnvironmentSystem(core.System, nn.Module):
         """
         self._transformation_outdoorTemperature = fn
 
+    def set_transformation_by_type(self, semantic_type, fn):
+        """Route a per-Brick-class transformation to the matching feed.
+
+        :meth:`Model.set_transformations` calls this once per semantic
+        node the component models, with the class whose rule won for
+        that node: temperature-sensor classes go to the
+        ``outdoorTemperature`` feed, solar radiance / irradiance classes
+        to the ``globalIrradiation`` feed (e.g. clipping the spikes a
+        BMS irradiance sensor logs).  Unknown classes are ignored.
+        """
+        uris = {str(semantic_type.uri)} | {
+            str(c.uri) for c in getattr(semantic_type, "super_classes", [])
+        }
+        brick = core.namespace.BRICK
+        if str(brick.Temperature_Sensor) in uris:
+            self._transformation_outdoorTemperature = fn
+        elif uris & {
+            str(brick.Solar_Irradiance_Sensor),
+            str(brick.Solar_Radiance_Sensor),
+            str(brick.Global_Solar_Irradiation_Sensor),
+        }:
+            self._transformation_globalIrradiation = fn
+
     def _apply(self, x):
         return x * self.a.get() + self.b.get()
 
@@ -793,7 +818,15 @@ def brick_signature_pattern():
     """
     weather_station = Node(cls=core.namespace.BRICK.Weather_Station)
     temp = Node(cls=core.namespace.BRICK.Outside_Air_Temperature_Sensor)
-    irrad = Node(cls=core.namespace.BRICK.Global_Solar_Irradiation_Sensor)
+    irrad = Node(
+        cls=(
+            # ``Global_Solar_Irradiation_Sensor`` is not a Brick class (it
+            # survives for graphs that extend Brick with it);
+            # ``Solar_Irradiance_Sensor`` is the Brick 1.4 class (W/m2).
+            core.namespace.BRICK.Global_Solar_Irradiation_Sensor,
+            core.namespace.BRICK.Solar_Irradiance_Sensor,
+        )
+    )
     externalref_temp = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     externalref_irrad = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     timeseriesid_temp = Node(cls=core.namespace.XSD.string)
@@ -877,7 +910,15 @@ def brick_signature_pattern_standalone():
     sensor's external reference timeseries ID.
     """
     temp = Node(cls=core.namespace.BRICK.Outside_Air_Temperature_Sensor)
-    irrad = Node(cls=core.namespace.BRICK.Global_Solar_Irradiation_Sensor)
+    irrad = Node(
+        cls=(
+            # ``Global_Solar_Irradiation_Sensor`` is not a Brick class (it
+            # survives for graphs that extend Brick with it);
+            # ``Solar_Irradiance_Sensor`` is the Brick 1.4 class (W/m2).
+            core.namespace.BRICK.Global_Solar_Irradiation_Sensor,
+            core.namespace.BRICK.Solar_Irradiance_Sensor,
+        )
+    )
     externalref_temp = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     externalref_irrad = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     timeseriesid_temp = Node(cls=core.namespace.XSD.string)

--- a/twin4build/tests/systems/outdoor_environment/test_feed_transformations.py
+++ b/twin4build/tests/systems/outdoor_environment/test_feed_transformations.py
@@ -1,0 +1,49 @@
+"""``OutdoorEnvironmentSystem.set_transformation_by_type`` routes a
+per-Brick-class unit conversion to the matching feed.
+
+Before, only the outdoor-temperature feed could receive a transformation
+(``set_transformation``), so a rule keyed by ``Solar_Irradiance_Sensor``
+(e.g. clipping the 1e8 W/m2 spikes a BMS irradiance sensor logs) was
+silently dropped and ``Model.set_transformations`` picked a single rule per
+component even when the component models sensors of different classes.
+"""
+
+# Standard library imports
+import unittest
+
+# Local application imports
+import twin4build
+import twin4build.core as core
+from twin4build.model.semantic_model.semantic_model import SemanticModel
+from twin4build.systems.outdoor_environment.outdoor_environment_system import (
+    OutdoorEnvironmentSystem,
+)
+
+twin4build._IS_TESTING = True
+
+BRICK = core.namespace.BRICK
+
+
+class TestFeedTransformations(unittest.TestCase):
+    def test_rules_reach_their_feeds(self):
+        sm = SemanticModel(id="feed_transformations")
+        outdoor = OutdoorEnvironmentSystem(id="outdoor")
+        clip = lambda x: min(x, 1500.0)  # noqa: E731
+        f2c = lambda x: (x - 32) * 5 / 9  # noqa: E731
+
+        outdoor.set_transformation_by_type(sm.get_type(BRICK.Solar_Irradiance_Sensor), clip)
+        outdoor.set_transformation_by_type(sm.get_type(BRICK.Outside_Air_Temperature_Sensor), f2c)
+        self.assertIs(outdoor._transformation_globalIrradiation, clip)
+        self.assertIs(outdoor._transformation_outdoorTemperature, f2c)
+
+        # A rule keyed by the generic Temperature_Sensor still reaches the
+        # temperature feed (subclass dispatch happens in Model).
+        outdoor.set_transformation_by_type(sm.get_type(BRICK.Temperature_Sensor), clip)
+        self.assertIs(outdoor._transformation_outdoorTemperature, clip)
+        # Unrelated classes are ignored.
+        outdoor.set_transformation_by_type(sm.get_type(BRICK.CO2_Sensor), f2c)
+        self.assertIs(outdoor._transformation_globalIrradiation, clip)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #157

Stacked on #160 (base is that branch).

## Summary
* `Model.set_transformations`: components exposing `set_transformation_by_type(semantic_type, fn)` receive one rule **per modeled semantic node** (that node's most-specific rule, with the class it won for). Components with only the legacy `set_transformation(fn)` hook get exactly the previous behaviour (single most-specific rule over all nodes).
* `OutdoorEnvironmentSystem.set_transformation_by_type`: temperature-sensor classes → `outdoorTemperature` feed, solar radiance / irradiance classes → new `_transformation_globalIrradiation`, applied inside the irradiation `TimeSeriesInputSystem` at initialize (same place as the temperature feed).

Motivation: the HTR irradiance sensor logs 1e8 W/m² spikes; a `Solar_Irradiance_Sensor` clipping rule never reached the feed and the zone temperatures diverged.

## Test plan
* New `tests/systems/outdoor_environment/test_feed_transformations.py`.
* `tests/systems/outdoor_environment`, `tests/model` (non-Graphviz) pass; the Brick 1.4 end-to-end test on the follow-up branch asserts the routing through `Model.set_transformations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
