### PR TITLE
feat: support Brick 1.4 / BMS-derived graphs in signature patterns (#148, supersedes #153)

### DIFF
--- a/twin4build/core/__init__.py
+++ b/twin4build/core/__init__.py
@@ -129,6 +129,7 @@ class ontology:
     RDFS = os.path.join(_ONTOLOGY_DIR, "rdfs.ttl")
     OWL = os.path.join(_ONTOLOGY_DIR, "owl.ttl")
     REC = os.path.join(_ONTOLOGY_DIR, "rec.ttl")
+    BRICKREF = os.path.join(_ONTOLOGY_DIR, "brickref.ttl")
 
     @classmethod
     def local_source(cls, namespace_uri) -> "str | None":
@@ -147,6 +148,12 @@ class ontology_remote:
     BRICK = "https://brickschema.org/schema/1.4.1/Brick.ttl"
     T4B = "http://twin4build.org/"
     BOT = "http://www.w3id.org/bot/bot.ttl"
+    # The Brick "ref" schema is not served under its namespace URI
+    # (https://brickschema.org/schema/Brick/ref# is a 404); the source of
+    # truth is the Brick repository.
+    BRICKREF = (
+        "https://raw.githubusercontent.com/BrickSchema/Brick/master/support/ref-schema.ttl"
+    )
 
     @classmethod
     def remote_source(cls, namespace_uri) -> "str | None":
@@ -165,6 +172,7 @@ _LOCAL_BY_NAMESPACE = {
     str(namespace.RDFS): ontology.RDFS,
     str(namespace.OWL): ontology.OWL,
     str(namespace.REC): ontology.REC,
+    str(namespace.BRICKREF): ontology.BRICKREF,
 }
 
 _REMOTE_BY_NAMESPACE = {
@@ -175,4 +183,5 @@ _REMOTE_BY_NAMESPACE = {
     str(namespace.BRICK): ontology_remote.BRICK,
     str(namespace.T4B): ontology_remote.T4B,
     str(namespace.BOT): ontology_remote.BOT,
+    str(namespace.BRICKREF): ontology_remote.BRICKREF,
 }

--- a/twin4build/core/ontologies/README.md
+++ b/twin4build/core/ontologies/README.md
@@ -25,3 +25,4 @@ against the same pinned versions, or bump the versions deliberately in
 | `rdfs.ttl` | http://www.w3.org/2000/01/rdf-schema# | - | W3C |
 | `owl.ttl` | http://www.w3.org/2002/07/owl# | - | W3C |
 | `rec.ttl` | https://w3id.org/rec# | latest | MIT |
+| `brickref.ttl` | https://raw.githubusercontent.com/BrickSchema/Brick/master/support/ref-schema.ttl (namespace `https://brickschema.org/schema/Brick/ref#`, not served at that URI) | master, fetched 2026-09-09 | BSD-3-Clause |

--- a/twin4build/core/ontologies/brickref.ttl
+++ b/twin4build/core/ontologies/brickref.ttl
@@ -1,0 +1,264 @@
+@prefix bacnet: <http://data.ashrae.org/bacnet/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
+@prefix s223: <http://data.ashrae.org/standard223#> .
+@prefix sdo: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ref:BACnetReferenceShape a sh:NodeShape ;
+    skos:definition "Infers a BACnetReference instance from the object of an hasExternalReference." ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition ref:BACnetReference ;
+            sh:object ref:BACnetReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
+
+ref:ExternalReferenceShape a sh:NodeShape ;
+    sh:property [ sh:message "All ExternalReference must have an rdfs:label" ;
+            sh:minCount 1 ;
+            sh:path rdfs:label ],
+        [ sh:message "All ExternalReference must have an skos:definition" ;
+            sh:minCount 1 ;
+            sh:path skos:definition ] ;
+    sh:target [ a sh:SPARQLTarget ;
+            sh:prefixes <https://brickschema.org/schema/Brick/ref> ;
+            sh:select """
+    SELECT ?this WHERE {
+     ?this rdfs:subClassOf+ ref:ExternalReference .
+    }
+    """ ] .
+
+ref:IFCReferenceShape a sh:NodeShape ;
+    skos:definition "Infers a IFCReference instance from the object of an hasExternalReference." ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition ref:IFCReference ;
+            sh:object ref:IFCReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
+
+ref:PreferredShape a sh:NodeShape ;
+    sh:property [ sh:message "An entity can only have one 'preferred' External Reference" ;
+            sh:path ref:hasExternalReference ;
+            sh:qualifiedMaxCount 1 ;
+            sh:qualifiedValueShape [ sh:class ref:ExternalReference ;
+                    sh:property [ sh:datatype xsd:boolean ;
+                            sh:hasValue true ;
+                            sh:path ref:preferred ] ] ] ;
+    sh:targetSubjectsOf ref:hasExternalReference .
+
+ref:TimeseriesReferenceShape a sh:NodeShape ;
+    skos:definition "Infers a TimeseriesReference instance from the object of an hasExternalReference." ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition ref:TimeseriesReference ;
+            sh:object ref:TimeseriesReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
+
+ref:bacnet-read-property a owl:DatatypeProperty ;
+    rdfs:label "bacnet-read-property" ;
+    rdfs:comment "The property of the BACnet object to read to get the current value of this entity." .
+
+ref:hasTimeseriesReference a owl:ObjectProperty ;
+    rdfs:label "hasTimeseriesReference" ;
+    rdfs:range ref:TimeseriesReference ;
+    rdfs:subPropertyOf ref:hasExternalReference ;
+    skos:definition "Metadata for accessing related timeseries data: Relates a data source (such as a Brick Point or 223 Property) to the TimeseriesReference that indicates where and how the data for this point is stored"@en .
+
+bacnet:contains a owl:ObjectProperty ;
+    rdfs:label "contains" ;
+    rdfs:comment "The BACnet device that hosts this BACnet object." ;
+    rdfs:range bacnet:device .
+
+bacnet:description a bacnet:StandardProperty,
+        owl:DatatypeProperty ;
+    bacnet:propertyEnum bacnet:PropertyIdentifier-description ;
+    bacnet:propertyName "description" ;
+    bacnet:propertyRef bacnet:Description ;
+    skos:definition "The content of the description field of the BACnet object." .
+
+bacnet:object-identifier a bacnet:StandardProperty,
+        rdf:Property,
+        owl:DatatypeProperty ;
+    rdfs:label "object-identifier" ;
+    bacnet:propertyEnum bacnet:PropertyIdentifier-object-identifier ;
+    bacnet:propertyName "object-identifier" ;
+    bacnet:propertyOf bacnet:Object ;
+    bacnet:propertyRef bacnet:Object_Identifier ;
+    rdfs:subPropertyOf bacnet:ReadableProperty ;
+    skos:definition "The BACnet object identifier" .
+
+bacnet:object-name a bacnet:StandardProperty,
+        owl:DatatypeProperty ;
+    bacnet:propertyEnum bacnet:PropertyIdentifier-object-name ;
+    bacnet:propertyName "object-name" ;
+    bacnet:propertyOf bacnet:Object ;
+    bacnet:propertyRef bacnet:Object_Name ;
+    rdfs:subPropertyOf bacnet:ReadableProperty ;
+    skos:definition "The content of the name field of the BACnet object." .
+
+bacnet:object-type a bacnet:StandardProperty,
+        rdf:Property,
+        owl:DatatypeProperty ;
+    rdfs:label "object-type" ;
+    bacnet:propertyEnum bacnet:PropertyIdentifier-object-type ;
+    bacnet:propertyName "object-type" ;
+    bacnet:propertyOf bacnet:Object ;
+    bacnet:propertyRef bacnet:Object_Type ;
+    rdfs:subPropertyOf bacnet:ReadableProperty ;
+    skos:definition "The type of the BACnet object" .
+
+<https://brickschema.org/schema/Brick/ref> a owl:Ontology ;
+    dcterms:creator ( [ a sdo:Person ;
+                sdo:email "gtfierro@mines.edu" ;
+                sdo:name "Gabe Fierro" ] ) ;
+    dcterms:title "Ref Schema" ;
+    sh:declare [ sh:namespace "http://www.w3.org/2000/01/rdf-schema#"^^xsd:anyURI ;
+            sh:prefix "rdfs" ],
+        [ sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
+            sh:prefix "rdf" ],
+        [ sh:namespace "https://brickschema.org/schema/Brick/ref#"^^xsd:anyURI ;
+            sh:prefix "ref" ],
+        [ sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
+            sh:prefix "sh" ],
+        [ sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
+            sh:prefix "rdf" ],
+        [ sh:namespace "http://www.w3.org/2002/07/owl#"^^xsd:anyURI ;
+            sh:prefix "owl" ] .
+
+ref:BACnetURI a owl:DatatypeProperty ;
+    rdfs:label "BACnetURI" ;
+    rdfs:comment "Clause Q.8 BACnet URI scheme: bacnet:// <device> / <object> [ / <property> [ / <index> ]]" .
+
+ref:hasIfcProjectReference a owl:ObjectProperty ;
+    rdfs:label "hasIfcProjectReference" ;
+    skos:definition "A reference to the IFC Project that defines this entity" .
+
+ref:hasTimeseriesId a owl:DatatypeProperty ;
+    rdfs:label "hasTimeseriesId" ;
+    skos:definition "The unique identifier (primary key) for this TimeseriesReference in some database"@en .
+
+ref:ifcFileLocation a owl:DatatypeProperty ;
+    rdfs:label "The location of the IFC file defining a project" ;
+    rdfs:range xsd:string .
+
+ref:ifcGlobalID a owl:DatatypeProperty ;
+    rdfs:label "ifcGlobalID" ;
+    skos:definition "The IFC Global ID of the entity" .
+
+ref:ifcName a owl:DatatypeProperty ;
+    rdfs:label "ifcName" ;
+    skos:definition "The name of the IFC entity" .
+
+ref:ifcProject a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "IfcProject" ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:ifcFileLocation ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:ifcProjectID ] .
+
+ref:ifcProjectID a owl:DatatypeProperty ;
+    rdfs:label "ifcProjectID" ;
+    skos:definition "The IFC ID of the containing project" .
+
+ref:preferred a owl:DatatypeProperty ;
+    skos:definition "An entity can have one 'preferred' External Reference. Consumers of the model should prioritize any external reference with the 'preferred' property" .
+
+ref:storedAt a owl:DatatypeProperty ;
+    rdfs:label "storedAt" ;
+    skos:definition "A reference to where the data for this TimeseriesReference is stored"@en .
+
+ref:BACnetReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "BACnet Reference" ;
+    rdfs:subClassOf ref:ExternalReference ;
+    skos:definition "A reference to the BACnet object represented by this entity." ;
+    sh:or ( [ sh:property [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:path bacnet:object-type ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:path bacnet:description ],
+                    [ a sh:PropertyShape ;
+                        sh:class bacnet:EngineeringUnitsEnumerationValue ;
+                        sh:maxCount 1 ;
+                        sh:minCount 0 ;
+                        sh:path bacnet:units ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:minLength 1 ;
+                        sh:path bacnet:object-name ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:minCount 1 ;
+                        sh:path bacnet:object-identifier ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype bacnet:Property ;
+                        sh:defaultValue bacnet:Present_Value ;
+                        sh:path ref:read-property ] ] [ sh:property [ a sh:PropertyShape ;
+                        skos:definition "Clause Q.8 BACnet URI scheme: bacnet:// <device> / <object> [ / <property> [ / <index> ]]" ;
+                        sh:datatype xsd:string ;
+                        sh:path ref:BACnetURI ] ] ) ;
+    sh:property [ a sh:PropertyShape ;
+            sh:class bacnet:device ;
+            sh:minCount 1 ;
+            sh:path bacnet:contains ] .
+
+ref:IFCReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "Industry Foundation Classes Reference" ;
+    rdfs:subClassOf ref:ExternalReference ;
+    skos:definition "A reference to an entity in an IFC project which may contain additional metadata about this entity." ;
+    sh:property [ a sh:PropertyShape ;
+            skos:definition "Name of the entity in IFC" ;
+            sh:datatype xsd:string ;
+            sh:path ref:ifcName ],
+        [ a sh:PropertyShape ;
+            skos:definition "The global ID of the entity in the IFC project" ;
+            sh:datatype xsd:string ;
+            sh:minCount 1 ;
+            sh:path ref:ifcGlobalID ],
+        [ a sh:PropertyShape ;
+            skos:definition "Reference to an IFC Project object, containing the project ID" ;
+            sh:class ref:ifcProject ;
+            sh:minCount 1 ;
+            sh:path ref:hasIfcProjectReference ] .
+
+ref:TimeseriesReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "Timeseries Reference" ;
+    rdfs:subClassOf ref:ExternalReference ;
+    skos:definition "A reference to a stream of timeseries data in a database. Contains the data for this entity" ;
+    sh:property [ a sh:PropertyShape ;
+            skos:definition "The identifier for the timeseries data corresponding to this point" ;
+            sh:datatype xsd:string ;
+            sh:minCount 1 ;
+            sh:path ref:hasTimeseriesId ],
+        [ a sh:PropertyShape ;
+            skos:definition "Refers to a database storing the timeseries data for the related point. Properties on this class are *to be determined*; feel free to add arbitrary properties onto Database instances for your particular deployment" ;
+            sh:nodeKind sh:IRIOrLiteral ;
+            sh:path ref:storedAt ] .
+
+ref:ExternalReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "External reference" ;
+    rdfs:subClassOf s223:ExternalReference ;
+    skos:definition "The parent class of all external reference types" .
+
+ref:hasExternalReference a owl:ObjectProperty ;
+    rdfs:label "hasExternalReference" ;
+    rdfs:subPropertyOf s223:hasExternalReference ;
+    skos:definition "Points to the external reference for this entity, which contains additional metadata/data not included in this graph." .
+

--- a/twin4build/core/ontologies/refresh.py
+++ b/twin4build/core/ontologies/refresh.py
@@ -27,6 +27,7 @@ SOURCES = {
     "rdfs.ttl": "http://www.w3.org/2000/01/rdf-schema#",
     "owl.ttl": "http://www.w3.org/2002/07/owl#",
     "rec.ttl": "https://w3id.org/rec#",
+    "brickref.ttl": ontology_remote.BRICKREF,
 }
 
 

--- a/twin4build/systems/air_handling_unit/air_handling_unit_system.py
+++ b/twin4build/systems/air_handling_unit/air_handling_unit_system.py
@@ -589,6 +589,11 @@ def brick_signature_pattern():
             core.namespace.BRICK.Enclosed_space,
             core.namespace.BRICK.Open_space,
             core.namespace.BRICK.HVAC_Zone,
+            # Brick 1.4 deprecates its location classes in favour of
+            # RealEstateCore (``brick:Room brick:isReplacedBy rec:Room``,
+            # ``brick:HVAC_Zone`` -> ``rec:HVACZone`` < ``rec:Zone``).
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
         )
     )
 
@@ -721,6 +726,11 @@ def brick_signature_pattern_vav_dampers():
             core.namespace.BRICK.Enclosed_space,
             core.namespace.BRICK.Open_space,
             core.namespace.BRICK.HVAC_Zone,
+            # Brick 1.4 deprecates its location classes in favour of
+            # RealEstateCore (``brick:Room brick:isReplacedBy rec:Room``,
+            # ``brick:HVAC_Zone`` -> ``rec:HVACZone`` < ``rec:Zone``).
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
         )
     )
     vavs = Node(cls=core.namespace.BRICK.VAV)
@@ -892,7 +902,102 @@ def brick_signature_pattern_vav_dampers():
 # ``add_modeled_node(ahu)`` and is mutually exclusive with the VAV
 # variant via the matcher's existing exclusion machinery (rather than
 # relying on the broken mixed-mutex semantics today).
+def brick_signature_pattern_vav_damper_commands():
+    """AHU pattern for VAV systems whose damper command is a direct VAV point.
+
+    Sibling of :func:`brick_signature_pattern_vav_dampers` for BMS-derived
+    BRICK graphs that do not model a ``brick:Damper`` equipment under each
+    VAV but attach the damper command point to the VAV itself (e.g. the
+    Hoeje-Taastrup Raadhus graph, where every VAV carries a
+    ``Damper_Position_Command`` next to its flow sensor / setpoint)::
+
+        AHU  feeds     VAV
+        VAV  feeds     Room / Zone
+        VAV  hasPoint  Damper_Position_Command | Damper_Position_Setpoint
+
+    Everything else (connections, Vector indexing by ``spaces``, the
+    free-floating optional outside-air sensor and the optional supply-air
+    temperature setpoint) mirrors the damper-equipment variant, so the
+    downstream BuildingSpace / sensor patterns line up on the same
+    ``spaces`` slots.
+
+    The two AHU patterns are mutually exclusive in practice: a VAV either
+    has a ``Damper`` part (damper-equipment variant) or a direct damper
+    command point (this variant).  A graph that models *both* on the same
+    VAV would produce two AirHandlingUnitSystem components per AHU (see the
+    note below on the non-exclusive multi-member ``ModeledNode`` mutex).
+    """
+    sp = SignaturePattern(
+        id="air_handling_unit_signature_pattern_brick_vav_damper_commands"
+    )
+
+    ahu = Node(cls=core.namespace.BRICK.AHU)
+    spaces = Node(
+        cls=(
+            core.namespace.BRICK.Room,
+            core.namespace.BRICK.Enclosed_space,
+            core.namespace.BRICK.Open_space,
+            core.namespace.BRICK.HVAC_Zone,
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
+        )
+    )
+    vavs = Node(cls=core.namespace.BRICK.VAV)
+    damper_cmds = Node(
+        cls=(
+            core.namespace.BRICK.Damper_Position_Command,
+            core.namespace.BRICK.Damper_Position_Setpoint,
+        )
+    )
+    sat_setpoint = Node(cls=core.namespace.BRICK.Supply_Air_Temperature_Setpoint)
+    oat_sensor = Node(cls=core.namespace.BRICK.Outside_Air_Temperature_Sensor)
+
+    feeds = Predicate((core.namespace.BRICK.feeds, core.namespace.FSO.feedsFluidTo))
+
+    sp.add_rule(SetAnyPathRule(subject=ahu, object=vavs, predicate=feeds))
+    sp.add_rule(StepRule(subject=vavs, object=spaces, predicate=feeds))
+    sp.add_rule(
+        StepRule(
+            subject=vavs, object=damper_cmds, predicate=core.namespace.BRICK.hasPoint
+        )
+    )
+    sp.add_node(oat_sensor, optional=True)
+    sp.add_rule(
+        OptionalRule(
+            subject=ahu,
+            object=sat_setpoint,
+            predicate=core.namespace.BRICK.hasPoint,
+        )
+    )
+
+    sp.add_connection(
+        spaces, "indoorTemperature", "exhaustTemperature", input_port_index=spaces
+    )
+    sp.add_connection(
+        damper_cmds,
+        "inputSignal",
+        "supplyDamperPosition",
+        output_port_index=damper_cmds,
+        input_port_index=spaces,
+    )
+    sp.add_connection(
+        damper_cmds,
+        "inputSignal",
+        "exhaustDamperPosition",
+        output_port_index=damper_cmds,
+        input_port_index=spaces,
+    )
+    sp.add_connection(sat_setpoint, "measuredValue", "supplyAirTemperatureSetpoint")
+    sp.add_connection(oat_sensor, "outdoorTemperature", "outdoorAirTemperature")
+
+    ModeledNode([ahu, vavs, damper_cmds])
+    return sp
+
+
 AirHandlingUnitSystem.add_signature_pattern(brick_signature_pattern_vav_dampers())
+AirHandlingUnitSystem.add_signature_pattern(
+    brick_signature_pattern_vav_damper_commands()
+)
 
 # Deprecated aliases (removed in twin4build 2.1)
 AirHandlingUnitTorchSystem = AirHandlingUnitSystem

--- a/twin4build/systems/building_space/building_space_system.py
+++ b/twin4build/systems/building_space/building_space_system.py
@@ -460,49 +460,128 @@ def saref_signature_pattern():
     return sp
 
 
-def brick_signature_pattern():  # Fits to site A
-    """
-    Get the BRICK-only signature pattern of the building space component.
+_BRICK_SPACE_CLASSES = (
+    core.namespace.BRICK.Room,
+    core.namespace.BRICK.Enclosed_space,
+    core.namespace.BRICK.Open_space,
+    core.namespace.BRICK.HVAC_Zone,
+    # Brick 1.4 deprecates its location classes in favour of
+    # RealEstateCore (``brick:Room brick:isReplacedBy rec:Room``,
+    # ``brick:HVAC_Zone`` -> ``rec:HVACZone`` < ``rec:Zone``).
+    core.namespace.REC.Room,
+    core.namespace.REC.Zone,
+    core.namespace.BOT.Space,
+)
 
-    Returns:
-        SignaturePattern: The BRICK-only signature pattern of the building space component.
-    """
+_SOLAR_SENSOR_CLASSES = (
+    # ``Global_Solar_Irradiation_Sensor`` is not a Brick class (it survives
+    # for graphs that extend Brick with it); ``Solar_Irradiance_Sensor`` is
+    # the Brick 1.4 class (W/m2).
+    core.namespace.BRICK.Global_Solar_Irradiation_Sensor,
+    core.namespace.BRICK.Solar_Irradiance_Sensor,
+)
 
-    ahu = Node(cls=core.namespace.BRICK.AHU)
-    # node1 = Node(cls=core.namespace.BRICK.Damper)
-    # node2 = Node(cls=core.namespace.BRICK.Zone)  # Compatibility with both site A and B (A uses Zone and B uses HVAC_Zone)
-    space = Node(
+_REHEAT_PART_CLASSES = (
+    core.namespace.BRICK.Heating_Coil,
+    core.namespace.BRICK.Cooling_Coil,
+    core.namespace.BRICK.Reheat_Valve,
+)
+_REHEAT_POINT_CLASSES = (
+    core.namespace.BRICK.Reheat_Command,
+    core.namespace.BRICK.Heating_Command,
+    core.namespace.BRICK.Valve_Command,
+)
+
+
+def _add_brick_volume_parameter(sp, space):
+    """Bind the room volume ``space brick:volume [ brick:value x ]`` to ``mass.V``.
+
+    The chain is *required* and the value holder is a modeled node: with an
+    ``OptionalRule`` chain the translator's disconnected-merge step treats
+    the free literal as a shared resource and copies one room's volume into
+    every other room (the same failure mode documented for the sensor
+    ``externalref`` chains).  Every Brick space pattern is therefore
+    registered twice -- with and without this chain -- and the MILP prefers
+    the with-volume variant (one more modeled node) whenever the graph
+    carries the geometry.
+    """
+    volume_node = Node(cls=(core.BlankNode,))
+    volume_value = Node(
         cls=(
-            core.namespace.BRICK.Room,
-            core.namespace.BRICK.Enclosed_space,
-            core.namespace.BRICK.Open_space,
-            core.namespace.BRICK.HVAC_Zone,
-            core.namespace.BOT.Space,
+            core.namespace.XSD.float,
+            core.namespace.XSD.double,
+            core.namespace.XSD.decimal,
+            core.namespace.XSD.integer,
         )
-    )  # TODO: '_space' should be '_Office', but the site b ttl file has a bug
-    solar_radiance_sensor = Node(cls=core.namespace.BRICK.Global_Solar_Irradiation_Sensor)
+    )
+    sp.add_rule(StepRule(subject=space, object=volume_node, predicate=core.namespace.BRICK.volume))
+    sp.add_rule(StepRule(subject=volume_node, object=volume_value, predicate=core.namespace.BRICK.value))
+    sp.add_parameter("mass.V", volume_value)
+    sp.add_modeled_node(volume_node)
+
+
+def _brick_space_pattern(topology: str, with_volume: bool):
+    """Factory for the Brick building-space patterns.
+
+    ``topology``:
+
+    * ``"vav_no_reheat"`` -- ``AHU feeds VAV feeds Room`` where the VAV is a
+      plain damper box (no coil part, no reheat / heating / valve command
+      point): the room receives ``AHU.supplyAirTemperature``.
+    * ``"vav"`` -- ``AHU feeds VAV feeds Room`` with reheat: the room receives
+      ``VAV.outletAirTemperature`` from a :class:`FanCoilUnitSystem`.
+    * ``"direct"`` -- AHU feeds the room through any path *not* via a VAV
+      (Mortar site A style): the room receives ``AHU.supplyAirTemperature``.
+
+    All variants share the ``space`` modeled node, so the MILP keeps one per
+    room; ``with_volume`` adds the ``brick:volume`` parameter chain (see
+    :func:`_add_brick_volume_parameter`).
+    """
+    ahu = Node(cls=core.namespace.BRICK.AHU)
+    vav = Node(cls=core.namespace.BRICK.VAV)
+    space = Node(cls=_BRICK_SPACE_CLASSES)
+    solar_radiance_sensor = Node(cls=_SOLAR_SENSOR_CLASSES)
     outside_air_temperature_sensor = Node(
         cls=core.namespace.BRICK.Outside_Air_Temperature_Sensor
     )
-
-    vav = Node(cls=core.namespace.BRICK.VAV)
-
     feeds = Predicate((core.namespace.BRICK.feeds, core.namespace.FSO.feedsFluidTo))
 
+    suffix = "_with_volume" if with_volume else ""
     sp = SignaturePattern(
-        id="building_space_signature_pattern_brick",
+        id=f"building_space_signature_pattern_brick_{topology}{suffix}"
     )
+    sp.add_node(solar_radiance_sensor, optional=True)  # not always present
+    sp.add_node(outside_air_temperature_sensor, optional=True)  # not always present
 
-    sp.add_node(solar_radiance_sensor, optional=True) # Optional because it is not always present
-    sp.add_node(outside_air_temperature_sensor, optional=True) # Optional because it is not always present
-
-    sp.add_rule(
-        AnyPathRule(
-            subject=ahu, object=space, predicate=feeds, endpoints_only=True
-        ) & NoStepRule(subject=ahu, object=vav, predicate=feeds)
-    )
-
-
+    if topology == "direct":
+        sp.add_rule(
+            AnyPathRule(subject=ahu, object=space, predicate=feeds, endpoints_only=True)
+            & NoStepRule(subject=ahu, object=vav, predicate=feeds)
+        )
+        sp.add_connection(ahu, "supplyAirTemperature", "supplyAirTemperature")
+    else:
+        sp.add_rule(StepRule(subject=ahu, object=vav, predicate=feeds))
+        sp.add_rule(StepRule(subject=vav, object=space, predicate=feeds))
+        if topology == "vav_no_reheat":
+            sp.add_rule(
+                NoStepRule(
+                    subject=vav,
+                    object=Node(cls=_REHEAT_PART_CLASSES),
+                    predicate=core.namespace.BRICK.hasPart,
+                )
+            )
+            sp.add_rule(
+                NoStepRule(
+                    subject=vav,
+                    object=Node(cls=_REHEAT_POINT_CLASSES),
+                    predicate=core.namespace.BRICK.hasPoint,
+                )
+            )
+            sp.add_connection(ahu, "supplyAirTemperature", "supplyAirTemperature")
+        elif topology == "vav":
+            sp.add_connection(vav, "outletAirTemperature", "supplyAirTemperature")
+        else:
+            raise ValueError(topology)
 
     sp.add_connection(
         ahu, "supplyAirFlowRate", "supplyAirFlowRate", output_port_index=space
@@ -510,105 +589,37 @@ def brick_signature_pattern():  # Fits to site A
     sp.add_connection(
         ahu, "exhaustAirFlowRate", "exhaustAirFlowRate", output_port_index=space
     )
-    # # sp.add_input("numberOfPeople", node5, "measuredValue")
+    sp.add_connection(solar_radiance_sensor, "globalIrradiation", "globalIrradiation")
     sp.add_connection(
         outside_air_temperature_sensor, "outdoorTemperature", "outdoorTemperature"
     )
-    sp.add_connection(
-        solar_radiance_sensor, "globalIrradiation", "globalIrradiation"
-    )
-    sp.add_connection(ahu, "supplyAirTemperature", "supplyAirTemperature")
-
+    if with_volume:
+        _add_brick_volume_parameter(sp, space)
     # Interzonal/boundary coupling is modeled by a separate WallSystem
     # (wired manually, or via a future wall/adjacency signature pattern).
     sp.add_modeled_node(space)
-
-    # sp_eq = SignaturePattern(
-    #     id="building_space_signature_pattern_brick_eq",
-    # )
-
-    #######################
-
-    # sp_eq.add_rule(
-    #     StepRule(subject=node0, object=node2, predicate=core.namespace.BRICK.feeds)
-    # )
-    # sp_eq.add_rule(
-    #     StepRule(subject=node2, object=node3, predicate=core.namespace.BRICK.hasPart)
-    # )
-
-    # # TODO: How to handle inverse predicates?
-    # diff = core.Diff()
-    # diff.remove(node0, core.namespace.BRICK.feeds, node2)
-    # diff.remove(node2, core.namespace.BRICK.isFedBy, node0)
-    # diff.add(node2, core.namespace.BRICK.hasPart, node3)
-
-    # sp.add_equivalent(sp_eq, diff)
-
     return sp
 
 
-def brick_signature_pattern_vav():
-    """
-    BRICK signature pattern for a building space served by an AHU via a VAV/FCU.
-
-    Mirrors physical reality: AHU → VAV/FCU (adds reheat) → Room.
-    The supply air temperature entering the room comes from the FCU outlet,
-    not directly from the AHU.
-
-    Topology::
-
-        AHU  feeds  VAV  feeds  Room
-
-    Connections:
-        AHU.supplyAirFlowRate  → BuildingSpace.supplyAirFlowRate
-        AHU.exhaustAirFlowRate → BuildingSpace.exhaustAirFlowRate
-        VAV.outletAirTemperature → BuildingSpace.supplyAirTemperature
-
-    The MILP solver will prefer this pattern over the direct AHU pattern when
-    a VAV is present between the AHU and the room, because it covers more nodes.
-    """
-    ahu = Node(cls=core.namespace.BRICK.AHU)
-    vav = Node(cls=core.namespace.BRICK.VAV)
-    space = Node(
-        cls=(
-            core.namespace.BRICK.Room,
-            core.namespace.BRICK.Enclosed_space,
-            core.namespace.BRICK.Open_space,
-            core.namespace.BRICK.HVAC_Zone,
-            core.namespace.BOT.Space,
-        )
-    )
-    solar_radiance_sensor = Node(cls=core.namespace.BRICK.Global_Solar_Irradiation_Sensor )
-    outside_air_temperature_sensor = Node(
-        cls=core.namespace.BRICK.Outside_Air_Temperature_Sensor
-    )
-
-    feeds = Predicate((core.namespace.BRICK.feeds, core.namespace.FSO.feedsFluidTo))
-
-    sp = SignaturePattern(id="building_space_signature_pattern_brick_vav")
-
-    sp.add_node(solar_radiance_sensor, optional=True) # Optional because it is not always present
-    sp.add_node(outside_air_temperature_sensor, optional=True) # Optional because it is not always present
-
-    sp.add_rule(StepRule(subject=ahu, object=vav, predicate=feeds))
-    sp.add_rule(StepRule(subject=vav, object=space, predicate=feeds))
-
-    sp.add_connection(
-        ahu, "supplyAirFlowRate", "supplyAirFlowRate", output_port_index=space
-    )
-    sp.add_connection(
-        ahu, "exhaustAirFlowRate", "exhaustAirFlowRate", output_port_index=space
-    )
-    sp.add_connection(vav, "outletAirTemperature", "supplyAirTemperature")
-    sp.add_connection(solar_radiance_sensor, "globalIrradiation", "globalIrradiation")
-    sp.add_connection(outside_air_temperature_sensor, "outdoorTemperature", "outdoorTemperature")
-    sp.add_modeled_node(space)
-
-    return sp
+def brick_signature_pattern_vav_no_reheat(with_volume: bool = False):
+    """See :func:`_brick_space_pattern` (``"vav_no_reheat"``)."""
+    return _brick_space_pattern("vav_no_reheat", with_volume)
 
 
-BuildingSpaceSystem.add_signature_pattern(brick_signature_pattern_vav())
-BuildingSpaceSystem.add_signature_pattern(brick_signature_pattern())
+def brick_signature_pattern_vav(with_volume: bool = False):
+    """See :func:`_brick_space_pattern` (``"vav"``); kept for site B / Mortar graphs."""
+    return _brick_space_pattern("vav", with_volume)
+
+
+def brick_signature_pattern(with_volume: bool = False):  # Fits to site A
+    """See :func:`_brick_space_pattern` (``"direct"``)."""
+    return _brick_space_pattern("direct", with_volume)
+
+
+for _with_volume in (True, False):
+    BuildingSpaceSystem.add_signature_pattern(brick_signature_pattern_vav_no_reheat(_with_volume))
+    BuildingSpaceSystem.add_signature_pattern(brick_signature_pattern_vav(_with_volume))
+    BuildingSpaceSystem.add_signature_pattern(brick_signature_pattern(_with_volume))
 BuildingSpaceSystem.add_signature_pattern(saref_signature_pattern())
 BuildingSpaceSystem.add_signature_pattern(saref_signature_pattern_sensor())
 

--- a/twin4build/systems/controller/controller_identification/controller_identification_pi_system.py
+++ b/twin4build/systems/controller/controller_identification/controller_identification_pi_system.py
@@ -38,6 +38,7 @@ from twin4build.translator.translator import (
     ModeledNode,
     Node,
     SetStepRule,
+    Predicate,
     SignaturePattern,
     StepRule,
 )
@@ -139,14 +140,7 @@ def brick_signature_pattern_vav():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(
-        cls=(
-            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
-            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
-            # the damper command tracks a supply-air-flow setpoint).
-            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
-        )
-    )
+    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
     actuators = Node(cls=core.namespace.BRICK.Command)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     timeseries_id = Node(cls=core.namespace.XSD.string)
@@ -174,6 +168,74 @@ def brick_signature_pattern_vav():
 ControllerIdentificationPISystem.add_signature_pattern(brick_signature_pattern_vav())
 
 
+def brick_signature_pattern_vav_room():
+    """BRICK VAV pattern with the loop variables on the *room* the VAV serves.
+
+    BMS-derived graphs (Hoeje-Taastrup Raadhus) keep the zone temperature
+    sensor and setpoints on the room and only the flow points and the
+    damper command on the VAV::
+
+        VAV  feeds     Room
+        Room hasPoint  Zone_Air_Temperature_Sensor              -> sensorValue
+        Room hasPoint  Zone_Air_Temperature_Setpoint (+ heating /
+                       cooling subclasses)                      -> setpointValue
+        VAV  hasPoint  Command (damper)                         -> actuator
+        VAV  hasPoint  Supply_Air_Flow_Setpoint                 -> onOffSignal
+
+    The loop identified is *damper = PI(zone temperature setpoint - zone
+    temperature)*, as in :func:`brick_signature_pattern_vav`.  The VAV's
+    supply-air-flow setpoint is the output of the room controller; it is
+    zero whenever the zone is off and positive otherwise, so it is offered
+    to the gate bus (``onOffSignal``) as the schedule-like signal, never as
+    a tracked setpoint (a pattern can feed one node into a port, so the
+    zone setpoints are not mirrored onto the gate bus here).
+    """
+    # The VAV is declared first on purpose: the matcher seeds each walk at
+    # the first node of the pattern graph (``ModeledNode`` members are not
+    # recognised as seeds), and seeding at the shared AHU would collapse
+    # the VAV branches of one room into a single match.
+    vav = Node(cls=core.namespace.BRICK.VAV)
+    room = Node(
+        cls=(
+            core.namespace.BRICK.Room,
+            core.namespace.BRICK.HVAC_Zone,
+            core.namespace.BRICK.Enclosed_space,
+            core.namespace.BRICK.Open_space,
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
+        )
+    )
+    sensors = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Sensor)
+    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
+    actuators = Node(cls=core.namespace.BRICK.Command)
+    flow_setpoints = Node(cls=core.namespace.BRICK.Supply_Air_Flow_Setpoint)
+    externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
+    timeseries_id = Node(cls=core.namespace.XSD.string)
+    feeds = Predicate((core.namespace.BRICK.feeds, core.namespace.FSO.feedsFluidTo))
+
+    sp = SignaturePattern(id="controller_identification_pi_vav_room_brick")
+    sp.add_rule(StepRule(subject=vav, object=room, predicate=feeds))
+    sp.add_rule(SetStepRule(subject=room, object=sensors, predicate=core.namespace.BRICK.hasPoint))
+    sp.add_rule(SetStepRule(subject=room, object=setpoints, predicate=core.namespace.BRICK.hasPoint))
+    sp.add_rule(SetStepRule(subject=vav, object=actuators, predicate=core.namespace.BRICK.hasPoint))
+    sp.add_rule(SetStepRule(subject=vav, object=flow_setpoints, predicate=core.namespace.BRICK.hasPoint))
+    sp.add_rule(StepRule(subject=actuators, object=externalref, predicate=core.namespace.BRICKREF.hasExternalReference))
+    sp.add_rule(StepRule(subject=externalref, object=timeseries_id, predicate=core.namespace.BRICKREF.hasTimeseriesId))
+
+    sp.add_connection(sensors, "measuredValue", "sensorValue", input_port_index=sensors)
+    sp.add_connection(setpoints, "measuredValue", "setpointValue", input_port_index=setpoints)
+    sp.add_connection(flow_setpoints, "measuredValue", "onOffSignal", input_port_index=flow_setpoints)
+    # Only the VAV and its command form the modeled identity: the room's
+    # sensor / setpoint points are shared by every VAV serving that room
+    # (four in some HTR rooms), and putting them in the group would make
+    # those VAV controllers mutually exclusive.
+    ModeledNode([vav, actuators])
+    return sp
+
+
+ControllerIdentificationPISystem.add_signature_pattern(brick_signature_pattern_vav_room())
+
+
 def brick_signature_pattern_vav_damper():
     """BRICK VAV pattern with damper-equipment-modeled actuator command.
 
@@ -189,14 +251,7 @@ def brick_signature_pattern_vav_damper():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(
-        cls=(
-            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
-            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
-            # the damper command tracks a supply-air-flow setpoint).
-            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
-        )
-    )
+    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
     damper_equip = Node(cls=core.namespace.BRICK.Damper)
     damper_cmd = Node(cls=core.namespace.BRICK.Damper_Position_Setpoint)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))

--- a/twin4build/systems/controller/controller_identification/controller_identification_pi_system.py
+++ b/twin4build/systems/controller/controller_identification/controller_identification_pi_system.py
@@ -139,7 +139,14 @@ def brick_signature_pattern_vav():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
+    setpoints = Node(
+        cls=(
+            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
+            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
+            # the damper command tracks a supply-air-flow setpoint).
+            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
+        )
+    )
     actuators = Node(cls=core.namespace.BRICK.Command)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     timeseries_id = Node(cls=core.namespace.XSD.string)
@@ -182,7 +189,14 @@ def brick_signature_pattern_vav_damper():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
+    setpoints = Node(
+        cls=(
+            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
+            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
+            # the damper command tracks a supply-air-flow setpoint).
+            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
+        )
+    )
     damper_equip = Node(cls=core.namespace.BRICK.Damper)
     damper_cmd = Node(cls=core.namespace.BRICK.Damper_Position_Setpoint)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))

--- a/twin4build/systems/controller/controller_identification/controller_identification_system.py
+++ b/twin4build/systems/controller/controller_identification/controller_identification_system.py
@@ -1463,7 +1463,14 @@ def brick_signature_pattern_vav():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
+    setpoints = Node(
+        cls=(
+            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
+            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
+            # the damper command tracks a supply-air-flow setpoint).
+            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
+        )
+    )
     actuators = Node(cls=core.namespace.BRICK.Command)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     timeseries_id = Node(cls=core.namespace.XSD.string)
@@ -1534,7 +1541,14 @@ def brick_signature_pattern_vav_damper():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
+    setpoints = Node(
+        cls=(
+            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
+            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
+            # the damper command tracks a supply-air-flow setpoint).
+            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
+        )
+    )
     damper_equip = Node(cls=core.namespace.BRICK.Damper)
     damper_cmd = Node(cls=core.namespace.BRICK.Damper_Position_Setpoint)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))

--- a/twin4build/systems/controller/controller_identification/controller_identification_system.py
+++ b/twin4build/systems/controller/controller_identification/controller_identification_system.py
@@ -1463,14 +1463,7 @@ def brick_signature_pattern_vav():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(
-        cls=(
-            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
-            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
-            # the damper command tracks a supply-air-flow setpoint).
-            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
-        )
-    )
+    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
     actuators = Node(cls=core.namespace.BRICK.Command)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     timeseries_id = Node(cls=core.namespace.XSD.string)
@@ -1541,14 +1534,7 @@ def brick_signature_pattern_vav_damper():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(
-        cls=(
-            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
-            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
-            # the damper command tracks a supply-air-flow setpoint).
-            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
-        )
-    )
+    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
     damper_equip = Node(cls=core.namespace.BRICK.Damper)
     damper_cmd = Node(cls=core.namespace.BRICK.Damper_Position_Setpoint)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))

--- a/twin4build/systems/sensor/sensor_system.py
+++ b/twin4build/systems/sensor/sensor_system.py
@@ -606,6 +606,11 @@ def get_brick_zone_air_temp_sensor_with_ref_pattern():
         cls=(
             core.namespace.BRICK.Room,
             core.namespace.BRICK.HVAC_Zone,
+            # Brick 1.4 deprecates its location classes in favour of
+            # RealEstateCore (``brick:Room brick:isReplacedBy rec:Room``,
+            # ``brick:HVAC_Zone`` -> ``rec:HVACZone`` < ``rec:Zone``).
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
             core.namespace.BRICK.Enclosed_space,
             core.namespace.BRICK.Open_space,
         )
@@ -671,6 +676,11 @@ def get_brick_zone_air_temp_sensor_virtual_pattern():
         cls=(
             core.namespace.BRICK.Room,
             core.namespace.BRICK.HVAC_Zone,
+            # Brick 1.4 deprecates its location classes in favour of
+            # RealEstateCore (``brick:Room brick:isReplacedBy rec:Room``,
+            # ``brick:HVAC_Zone`` -> ``rec:HVACZone`` < ``rec:Zone``).
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
             core.namespace.BRICK.Enclosed_space,
             core.namespace.BRICK.Open_space,
         )
@@ -693,6 +703,127 @@ def get_brick_zone_air_temp_sensor_virtual_pattern():
     )
     sp.add_connection(room, "indoorTemperature", "measuredValue")
     sp.add_modeled_node(sensor)
+    return sp
+
+
+def _brick_room_classes():
+    return (
+        core.namespace.BRICK.Room,
+        core.namespace.BRICK.HVAC_Zone,
+        core.namespace.BRICK.Enclosed_space,
+        core.namespace.BRICK.Open_space,
+        core.namespace.REC.Room,
+        core.namespace.REC.Zone,
+    )
+
+
+def get_brick_room_zone_air_temp_sensor_with_ref_pattern():
+    """BRICK Zone_Air_Temperature_Sensor attached to the *room*, with a timeseries reference.
+
+    BMS-derived graphs (e.g. Hoeje-Taastrup Raadhus) hang the zone
+    temperature sensor off the room rather than off the VAV serving it::
+
+        Zone_Air_Temperature_Sensor  isPointOf             Room / Zone
+        Zone_Air_Temperature_Sensor  hasExternalReference  <ExternalRef/BNode>
+                                                                +- hasTimeseriesId -> <uuid>
+
+    Same wiring as :func:`get_brick_zone_air_temp_sensor_with_ref_pattern`
+    (``room.indoorTemperature -> sensor.measuredValue``); paired with
+    :func:`get_brick_room_zone_air_temp_sensor_virtual_pattern` following
+    the two-pattern split explained above.
+    """
+    sensor = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Sensor)
+    room = Node(cls=_brick_room_classes())
+    externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
+    timeseries_id = Node(cls=core.namespace.XSD.string)
+
+    sp = SignaturePattern(id="brick_room_zone_air_temp_sensor_with_ref_pattern")
+    sp.add_rule(
+        StepRule(subject=sensor, object=room, predicate=core.namespace.BRICK.isPointOf)
+    )
+    sp.add_rule(
+        StepRule(
+            subject=sensor,
+            object=externalref,
+            predicate=core.namespace.BRICKREF.hasExternalReference,
+        )
+    )
+    sp.add_rule(
+        StepRule(
+            subject=externalref,
+            object=timeseries_id,
+            predicate=core.namespace.BRICKREF.hasTimeseriesId,
+        )
+    )
+    sp.add_parameter("uuid", timeseries_id)
+    sp.add_connection(room, "indoorTemperature", "measuredValue")
+    sp.add_modeled_node(sensor)
+    sp.add_modeled_node(externalref)
+    return sp
+
+
+def get_brick_room_zone_air_temp_sensor_virtual_pattern():
+    """BRICK Zone_Air_Temperature_Sensor attached to the *room*, no timeseries reference.
+
+    Topology::
+
+        Zone_Air_Temperature_Sensor  isPointOf  Room / Zone
+
+    Mutually exclusive with
+    :func:`get_brick_room_zone_air_temp_sensor_with_ref_pattern` via the
+    shared ``sensor`` modeled node; the with-ref variant wins when both match.
+    """
+    sensor = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Sensor)
+    room = Node(cls=_brick_room_classes())
+
+    sp = SignaturePattern(id="brick_room_zone_air_temp_sensor_virtual_pattern")
+    sp.add_rule(
+        StepRule(subject=sensor, object=room, predicate=core.namespace.BRICK.isPointOf)
+    )
+    sp.add_connection(room, "indoorTemperature", "measuredValue")
+    sp.add_modeled_node(sensor)
+    return sp
+
+
+def get_brick_room_zone_co2_sensor_with_ref_pattern():
+    """BRICK Zone_CO2_Level_Sensor attached to the room, with a timeseries reference.
+
+    Topology::
+
+        Zone_CO2_Level_Sensor  isPointOf             Room / Zone
+        Zone_CO2_Level_Sensor  hasExternalReference  <ExternalRef/BNode>
+                                                         +- hasTimeseriesId -> <uuid>
+
+    Wires the BuildingSpace mass-balance output ``indoorCO2`` into the
+    sensor so simulated and measured CO2 can be compared.
+    """
+    sensor = Node(cls=core.namespace.BRICK.Zone_CO2_Level_Sensor)
+    room = Node(cls=_brick_room_classes())
+    externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
+    timeseries_id = Node(cls=core.namespace.XSD.string)
+
+    sp = SignaturePattern(id="brick_room_zone_co2_sensor_with_ref_pattern")
+    sp.add_rule(
+        StepRule(subject=sensor, object=room, predicate=core.namespace.BRICK.isPointOf)
+    )
+    sp.add_rule(
+        StepRule(
+            subject=sensor,
+            object=externalref,
+            predicate=core.namespace.BRICKREF.hasExternalReference,
+        )
+    )
+    sp.add_rule(
+        StepRule(
+            subject=externalref,
+            object=timeseries_id,
+            predicate=core.namespace.BRICKREF.hasTimeseriesId,
+        )
+    )
+    sp.add_parameter("uuid", timeseries_id)
+    sp.add_connection(room, "indoorCO2", "measuredValue")
+    sp.add_modeled_node(sensor)
+    sp.add_modeled_node(externalref)
     return sp
 
 
@@ -778,6 +909,11 @@ def get_brick_supply_air_flow_sensor_with_ref_pattern():
         cls=(
             core.namespace.BRICK.Room,
             core.namespace.BRICK.HVAC_Zone,
+            # Brick 1.4 deprecates its location classes in favour of
+            # RealEstateCore (``brick:Room brick:isReplacedBy rec:Room``,
+            # ``brick:HVAC_Zone`` -> ``rec:HVACZone`` < ``rec:Zone``).
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
             core.namespace.BRICK.Enclosed_space,
             core.namespace.BRICK.Open_space,
         )
@@ -849,6 +985,11 @@ def get_brick_supply_air_flow_sensor_virtual_pattern():
         cls=(
             core.namespace.BRICK.Room,
             core.namespace.BRICK.HVAC_Zone,
+            # Brick 1.4 deprecates its location classes in favour of
+            # RealEstateCore (``brick:Room brick:isReplacedBy rec:Room``,
+            # ``brick:HVAC_Zone`` -> ``rec:HVACZone`` < ``rec:Zone``).
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
             core.namespace.BRICK.Enclosed_space,
             core.namespace.BRICK.Open_space,
         )
@@ -969,6 +1110,9 @@ class SensorSystem(core.System):
         # split is required.
         get_brick_zone_air_temp_sensor_with_ref_pattern(),
         get_brick_zone_air_temp_sensor_virtual_pattern(),
+        get_brick_room_zone_air_temp_sensor_with_ref_pattern(),
+        get_brick_room_zone_air_temp_sensor_virtual_pattern(),
+        get_brick_room_zone_co2_sensor_with_ref_pattern(),
         get_brick_ahu_supply_air_temp_sensor_with_ref_pattern(),
         get_brick_ahu_supply_air_temp_sensor_virtual_pattern(),
         get_brick_supply_air_flow_sensor_with_ref_pattern(),

--- a/twin4build/tests/translator/test_brick14_bms_patterns.py
+++ b/twin4build/tests/translator/test_brick14_bms_patterns.py
@@ -1,0 +1,168 @@
+"""End-to-end translation of a small Brick 1.4 / BMS-style graph.
+
+Mirrors the topology of the Hoeje-Taastrup Raadhus graph: rooms are
+``rec:Room``, the VAV carries its ``Damper_Position_Command`` as a direct
+point (no ``brick:Damper`` equipment), the zone temperature / CO2 sensors
+hang off the room, and the weather station has a
+``brick:Solar_Irradiance_Sensor``.  Before the pattern additions none of
+BuildingSpace / AirHandlingUnit / OutdoorEnvironment matched.
+"""
+
+# Standard library imports
+import os
+import shutil
+import unittest
+
+# Third party imports
+from rdflib import RDF, BNode, Literal, Namespace, URIRef
+
+# Local application imports
+import twin4build
+import twin4build.core as core
+from twin4build.model.semantic_model.semantic_model import SemanticModel
+from twin4build.systems.air_handling_unit.air_handling_unit_system import (
+    AirHandlingUnitSystem,
+)
+from twin4build.systems.building_space.building_space_system import (
+    BuildingSpaceSystem,
+)
+from twin4build.systems.outdoor_environment.outdoor_environment_system import (
+    OutdoorEnvironmentSystem,
+)
+from twin4build.systems.sensor.sensor_system import SensorSystem
+from twin4build.translator.translator import Translator
+
+twin4build._IS_TESTING = True
+
+BRICK = core.namespace.BRICK
+REC = core.namespace.REC
+REF = core.namespace.BRICKREF
+EX = Namespace("http://example.org/htr#")
+
+
+def _point(g, owner, name, cls, tsid=True):
+    p = EX[name]
+    g.add((owner, BRICK.hasPoint, p))
+    g.add((p, RDF.type, cls))
+    if tsid:
+        ref = EX[name + "_ref"]
+        g.add((p, REF.hasExternalReference, ref))
+        g.add((ref, RDF.type, REF.TimeseriesReference))
+        g.add((ref, REF.hasTimeseriesId, Literal(name)))
+    return p
+
+
+def build_graph(sm):
+    g = sm.instance_graph
+    ahu, ws = EX.AHU01, EX.WS01
+    g.add((ahu, RDF.type, BRICK.AHU))
+    _point(g, ahu, "AHU01_SAT", BRICK.Supply_Air_Temperature_Sensor)
+    _point(g, ahu, "AHU01_SAT_SP", BRICK.Supply_Air_Temperature_Setpoint)
+    g.add((ws, RDF.type, BRICK.Weather_Station))
+    _point(g, ws, "WS01_TOUT", BRICK.Outside_Air_Temperature_Sensor)
+    _point(g, ws, "WS01_SOLAR", BRICK.Solar_Irradiance_Sensor)
+    for i in (1, 2):
+        room, vav = EX[f"R0{i}"], EX[f"R0{i}_VAV01"]
+        g.add((room, RDF.type, REC.Room))
+        vol = BNode()
+        g.add((room, BRICK.volume, vol))
+        g.add((vol, BRICK.value, Literal(20.0 + i)))
+        g.add((vav, RDF.type, BRICK.VAV))
+        g.add((ahu, BRICK.feeds, vav))
+        g.add((vav, BRICK.feeds, room))
+        _point(g, vav, f"R0{i}_VAV01_CMD", BRICK.Damper_Position_Command)
+        _point(g, vav, f"R0{i}_FCI01", BRICK.Supply_Air_Flow_Sensor)
+        _point(g, room, f"R0{i}_TRU01", BRICK.Zone_Air_Temperature_Sensor)
+        _point(g, room, f"R0{i}_CO201", BRICK.Zone_CO2_Level_Sensor)
+    # ``isPointOf`` is only materialised by the reasoner from ``hasPoint``
+    # (owl:inverseOf) -- the patterns rely on that, as for real graphs.
+
+
+class TestBrick14BmsPatterns(unittest.TestCase):
+    MODEL_ID = "test_brick14_bms_patterns"
+
+    def tearDown(self):
+        path = os.path.join("generated_files", "models", self.MODEL_ID)
+        if os.path.exists(path):
+            shutil.rmtree(path)
+
+    def test_translation_matches_physics_and_sensors(self):
+        sm = SemanticModel(id=self.MODEL_ID, namespaces={"ex": str(EX)})
+        build_graph(sm)
+        model = Translator().translate(
+            sm,
+            systems=[
+                BuildingSpaceSystem,
+                AirHandlingUnitSystem,
+                OutdoorEnvironmentSystem,
+                SensorSystem,
+            ],
+            id=self.MODEL_ID,
+        )
+        by_cls = {}
+        for c in model.components.values():
+            by_cls.setdefault(type(c).__name__, []).append(c)
+
+        # Rooms model the ``rec:Room`` node plus the ``brick:volume`` blank
+        # node, so the id is the composite ``[<bnode>][R0i]`` form; resolve
+        # them through the translator's sim -> sem map instead.
+        translator = model._translator
+        rooms = {}
+        for c in by_cls["BuildingSpaceSystem"]:
+            uris = {str(n.uri) for n in translator.sim2sem_map[c]}
+            (room_uri,) = [u for u in uris if u.startswith(str(EX))]
+            rooms[room_uri.split("#")[-1]] = c
+        self.assertEqual(sorted(rooms), ["R01", "R02"])
+        self.assertEqual(len(by_cls["AirHandlingUnitSystem"]), 1)
+        self.assertEqual(len(by_cls["OutdoorEnvironmentSystem"]), 1)
+
+        def incoming(comp, port):
+            for cp in comp.connects_at:
+                if cp.input_port == port:
+                    return [conn.connects_system for conn in cp.connects_system_through]
+            return []
+
+        ahu = by_cls["AirHandlingUnitSystem"][0]
+        for room in rooms.values():
+            self.assertEqual(incoming(room, "supplyAirFlowRate"), [ahu])
+            # Coil-less VAV: the room breathes AHU supply air directly.
+            self.assertEqual(incoming(room, "supplyAirTemperature"), [ahu])
+            self.assertEqual(
+                [type(c).__name__ for c in incoming(room, "outdoorTemperature")],
+                ["OutdoorEnvironmentSystem"],
+            )
+        # Room volume read from ``brick:volume [brick:value x]``.
+        self.assertAlmostEqual(float(rooms["R01"].mass.V.get()), 21.0)
+        self.assertAlmostEqual(float(rooms["R02"].mass.V.get()), 22.0)
+        self.assertEqual(len(incoming(ahu, "exhaustTemperature")), 2)
+        self.assertEqual(
+            [c.uuid for c in incoming(ahu, "supplyAirTemperatureSetpoint")],
+            ["AHU01_SAT_SP"],
+        )
+
+        # Room-attached zone sensors are wired to the modelled room state.
+        sensors = {c.uuid: c for c in by_cls["SensorSystem"] if c.uuid}
+        for i in (1, 2):
+            self.assertEqual(incoming(sensors[f"R0{i}_TRU01"], "measuredValue"), [rooms[f"R0{i}"]])
+            self.assertEqual(incoming(sensors[f"R0{i}_CO201"], "measuredValue"), [rooms[f"R0{i}"]])
+            self.assertEqual(incoming(sensors[f"R0{i}_FCI01"], "measuredValue"), [ahu])
+        self.assertEqual(incoming(sensors["AHU01_SAT"], "measuredValue"), [ahu])
+
+        outdoor = by_cls["OutdoorEnvironmentSystem"][0]
+        self.assertEqual(outdoor.uuid_outdoorTemperature, "WS01_TOUT")
+        self.assertEqual(outdoor.uuid_globalIrradiation, "WS01_SOLAR")
+        # Per-feed transformation dispatch: the irradiance rule must reach
+        # the irradiation feed, the temperature rule the temperature feed.
+        clip = lambda x: min(x, 1500.0)  # noqa: E731
+        f2c = lambda x: (x - 32) * 5 / 9  # noqa: E731
+        model.set_transformations(
+            {BRICK.Solar_Irradiance_Sensor: clip, BRICK.Temperature_Sensor: f2c}
+        )
+        self.assertIs(outdoor._transformation_globalIrradiation, clip)
+        self.assertIs(outdoor._transformation_outdoorTemperature, f2c)
+        # The vendored Brick ``ref`` schema parses offline.
+        self.assertNotIn(str(REF), sm.error_namespaces)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/twin4build/tests/translator/test_brick14_bms_patterns.py
+++ b/twin4build/tests/translator/test_brick14_bms_patterns.py
@@ -26,6 +26,9 @@ from twin4build.systems.air_handling_unit.air_handling_unit_system import (
 from twin4build.systems.building_space.building_space_system import (
     BuildingSpaceSystem,
 )
+from twin4build.systems.controller.controller_identification.controller_identification_pi_system import (
+    ControllerIdentificationPISystem,
+)
 from twin4build.systems.outdoor_environment.outdoor_environment_system import (
     OutdoorEnvironmentSystem,
 )
@@ -72,10 +75,31 @@ def build_graph(sm):
         g.add((vav, BRICK.feeds, room))
         _point(g, vav, f"R0{i}_VAV01_CMD", BRICK.Damper_Position_Command)
         _point(g, vav, f"R0{i}_FCI01", BRICK.Supply_Air_Flow_Sensor)
+        _point(g, vav, f"R0{i}_SpFCI01_C", BRICK.Supply_Air_Flow_Setpoint)
         _point(g, room, f"R0{i}_TRU01", BRICK.Zone_Air_Temperature_Sensor)
+        _point(g, room, f"R0{i}_SpTRU01", BRICK.Zone_Air_Temperature_Setpoint)
+        _point(g, room, f"R0{i}_SpTRU01_K", BRICK.Zone_Air_Cooling_Temperature_Setpoint)
         _point(g, room, f"R0{i}_CO201", BRICK.Zone_CO2_Level_Sensor)
+    # A second VAV on room R02 (HTR rooms have up to four): each VAV must
+    # get its own controller although they share the room's sensor and
+    # setpoints (regression: the walker used to keep one match per room).
+    vav2 = EX["R02_VAV02"]
+    g.add((vav2, RDF.type, BRICK.VAV))
+    g.add((ahu, BRICK.feeds, vav2))
+    g.add((vav2, BRICK.feeds, EX["R02"]))
+    _point(g, vav2, "R02_VAV02_CMD", BRICK.Damper_Position_Command)
+    _point(g, vav2, "R02_FCI02", BRICK.Supply_Air_Flow_Sensor)
+    _point(g, vav2, "R02_SpFCI02_C", BRICK.Supply_Air_Flow_Setpoint)
     # ``isPointOf`` is only materialised by the reasoner from ``hasPoint``
     # (owl:inverseOf) -- the patterns rely on that, as for real graphs.
+
+
+def _outgoing_components(component, port):
+    out = []
+    for conn in component.connected_through:
+        if conn.output_port == port:
+            out.extend(cp.connection_point_of for cp in conn.connects_system_at)
+    return out
 
 
 class TestBrick14BmsPatterns(unittest.TestCase):
@@ -96,6 +120,7 @@ class TestBrick14BmsPatterns(unittest.TestCase):
                 AirHandlingUnitSystem,
                 OutdoorEnvironmentSystem,
                 SensorSystem,
+                ControllerIdentificationPISystem,
             ],
             id=self.MODEL_ID,
         )
@@ -134,7 +159,7 @@ class TestBrick14BmsPatterns(unittest.TestCase):
         # Room volume read from ``brick:volume [brick:value x]``.
         self.assertAlmostEqual(float(rooms["R01"].mass.V.get()), 21.0)
         self.assertAlmostEqual(float(rooms["R02"].mass.V.get()), 22.0)
-        self.assertEqual(len(incoming(ahu, "exhaustTemperature")), 2)
+        self.assertEqual(len(incoming(ahu, "exhaustTemperature")), 2)  # one slot per room
         self.assertEqual(
             [c.uuid for c in incoming(ahu, "supplyAirTemperatureSetpoint")],
             ["AHU01_SAT_SP"],
@@ -147,6 +172,29 @@ class TestBrick14BmsPatterns(unittest.TestCase):
             self.assertEqual(incoming(sensors[f"R0{i}_CO201"], "measuredValue"), [rooms[f"R0{i}"]])
             self.assertEqual(incoming(sensors[f"R0{i}_FCI01"], "measuredValue"), [ahu])
         self.assertEqual(incoming(sensors["AHU01_SAT"], "measuredValue"), [ahu])
+
+        # One PI-CITS per VAV, with the loop variables taken from the room:
+        # zone temperature sensor -> sensorValue, zone temperature setpoints
+        # -> setpointValue, and the VAV flow setpoint on the gate bus.
+        cits_list = by_cls["ControllerIdentificationPISystem"]
+        self.assertEqual(len(cits_list), 3)  # R01_VAV01, R02_VAV01, R02_VAV02
+        gates = []
+        for cits in cits_list:
+            uuids = lambda port: sorted(c.uuid for c in incoming(cits, port))  # noqa: E731
+            (sensor_uuid,) = uuids("sensorValue")
+            i = sensor_uuid[2]  # R0<i>_TRU01
+            self.assertEqual(sensor_uuid, f"R0{i}_TRU01")
+            self.assertEqual(uuids("setpointValue"), [f"R0{i}_SpTRU01", f"R0{i}_SpTRU01_K"])
+            (gate,) = uuids("onOffSignal")
+            gates.append(gate)
+            # Every controller feeds its historised command sensor ...
+            downstream = _outgoing_components(cits, "inputSignal")
+            self.assertTrue(any(isinstance(c, SensorSystem) for c in downstream))
+        self.assertEqual(sorted(gates), ["R01_SpFCI01_C", "R02_SpFCI01_C", "R02_SpFCI02_C"])
+        # ... and the AHU damper slot of each room is driven by exactly one
+        # of that room's controllers (one connection per Vector slot).
+        drivers = [c for c in cits_list if ahu in _outgoing_components(c, "inputSignal")]
+        self.assertEqual(len(drivers), 2)
 
         outdoor = by_cls["OutdoorEnvironmentSystem"][0]
         self.assertEqual(outdoor.uuid_outdoorTemperature, "WS01_TOUT")

--- a/twin4build/tests/translator/test_brick14_bms_patterns.py
+++ b/twin4build/tests/translator/test_brick14_bms_patterns.py
@@ -195,6 +195,25 @@ class TestBrick14BmsPatterns(unittest.TestCase):
         # of that room's controllers (one connection per Vector slot).
         drivers = [c for c in cits_list if ahu in _outgoing_components(c, "inputSignal")]
         self.assertEqual(len(drivers), 2)
+        # ... and both damper ports of a zone slot are driven by the SAME
+        # controller.  Constraint 4 of the MILP bounds each port on its own,
+        # so R02's two VAVs could split that zone's ports between them, an
+        # equally optimal solution that solver tie-breaking picked on some
+        # platforms (three drivers instead of two); the slot-coherence
+        # constraint (4b) rules it out for every solver.
+        driver_by_slot = {}
+        for cp in ahu.connects_at:
+            if cp.input_port not in ("supplyDamperPosition", "exhaustDamperPosition"):
+                continue
+            for conn in cp.connects_system_through:
+                slot = int(cp.input_port_index[conn])
+                driver_by_slot.setdefault(slot, {})[cp.input_port] = conn.connects_system
+        self.assertEqual(len(driver_by_slot), 2)  # one slot per room
+        for slot, ports in driver_by_slot.items():
+            self.assertEqual(
+                set(ports), {"supplyDamperPosition", "exhaustDamperPosition"}, slot
+            )
+            self.assertIs(ports["supplyDamperPosition"], ports["exhaustDamperPosition"])
 
         outdoor = by_cls["OutdoorEnvironmentSystem"][0]
         self.assertEqual(outdoor.uuid_outdoorTemperature, "WS01_TOUT")

--- a/twin4build/translator/translator.py
+++ b/twin4build/translator/translator.py
@@ -1812,6 +1812,59 @@ class Translator:
                 LinearConstraint(A_one_input, b_one_input_l, b_one_input_u)
             )
 
+        # 4b. Slot-coherence constraints: a source with candidate edges into
+        # several ports of the same target slot (one damper command feeding
+        # both ``supplyDamperPosition[k]`` and ``exhaustDamperPosition[k]``)
+        # is selected for all of those ports or for none.  Constraint 4
+        # bounds each port on its own, so two candidate sources for one zone
+        # slot could split that zone's ports between them: an equally optimal
+        # solution the solver picks by tie-breaking, and one that wires two
+        # controllers to a single zone.  Per port the edges are summed, so a
+        # port with several candidate edges from the same source is not
+        # forced off by a sibling with one.
+        conn_by_source_slot = {}
+        for e_idx, (
+            source_component,
+            target_component,
+            _,
+            target_key,
+            _,
+            input_port_index,
+        ) in E_idx_to_conn.items():
+            if input_port_index is None:
+                continue
+            by_key = conn_by_source_slot.setdefault(
+                (source_component, target_component, input_port_index), {}
+            )
+            by_key.setdefault(target_key, []).append(e_idx)
+
+        slot_coherence_constraints = []
+        for (_source, _target, slot_idx), by_key in conn_by_source_slot.items():
+            if len(by_key) < 2:
+                continue
+            first_key, *other_keys = list(by_key)
+            for other_key in other_keys:
+                row = np.zeros(total_vars)
+                for e_idx in by_key[first_key]:
+                    row[e_idx] += 1
+                for e_idx in by_key[other_key]:
+                    row[e_idx] -= 1
+                slot_coherence_constraints.append(row)
+                constraint_info.append(
+                    f"sum(E[{first_key}]) - sum(E[{other_key}]) = 0 "
+                    f"(slot {slot_idx} coherence)"
+                )
+
+        if slot_coherence_constraints:
+            A_slot_coherence = np.vstack(slot_coherence_constraints)
+            constraints_list.append(
+                LinearConstraint(
+                    A_slot_coherence,
+                    np.zeros(len(slot_coherence_constraints)),
+                    np.zeros(len(slot_coherence_constraints)),
+                )
+            )
+
         # 5. Modeled-identity mutex constraints.
         #
         # Two kinds of mutual exclusion apply here:


### PR DESCRIPTION
Closes #148

Supersedes #153 (same scope, rebuilt on a new base and extended with the BuildingSpace pattern factory). Stacked on #161 → #160 → #149 (base is the per-feed-transformations branch); the end-to-end test needs the walker fixes (stand-alone `NoStepRule`, hub leak) and the per-feed transformation dispatch.

## Summary
Makes the Brick signature patterns match Brick 1.4 graphs generated from BMS point names (Hoeje-Taastrup Raadhus, `HTR-fresh`), without changing behaviour for Mortar-style graphs:

* **REC location classes**: `rec:Room` / `rec:Zone` (covers `rec:HVACZone`) in every space class tuple of the BuildingSpace, AHU and sensor patterns (Brick 1.4: `brick:Room brick:isReplacedBy rec:Room`).
* **Solar irradiance**: `brick:Solar_Irradiance_Sensor` (the actual Brick class) accepted next to `Global_Solar_Irradiation_Sensor`.
* **Vendored Brick `ref` schema**: `core/ontologies/brickref.ttl` (from `BrickSchema/Brick` `support/ref-schema.ttl`), registered in `core.ontology` / `ontology_remote` / `refresh.py` / README.
* **AHU pattern** `brick_signature_pattern_vav_damper_commands`: VAVs whose `Damper_Position_Command` / `Damper_Position_Setpoint` is a direct point (no `brick:Damper` equipment).
* **BuildingSpace patterns rebuilt through one factory** `_brick_space_pattern(topology, with_volume)`: topologies `vav_no_reheat` (new: `NoStepRule` on coil parts / reheat commands, room receives `AHU.supplyAirTemperature`), `vav` (unchanged wiring) and `direct` (unchanged); `with_volume` variants read `space brick:volume [brick:value x]` into `mass.V` (required chain with the blank node as a modeled node, so the MILP prefers them when geometry exists; rooms with geometry therefore get composite `[<bnode>][room]` ids like the sensors do).
* **Room-attached sensors**: zone air temperature (with-ref / virtual) and CO2 patterns for sensors that hang off the room instead of the VAV.
* **CITS**: `Supply_Air_Flow_Setpoint` accepted as tracked setpoint in the VAV controller-identification patterns.

## Test plan
* `tests/translator/test_brick14_bms_patterns.py`: end-to-end translation of a small Brick 1.4 graph (2 `rec:Room`s with `brick:volume`, VAVs with direct damper commands, room-attached T / CO2 sensors, weather station with irradiance) asserts components, wiring (incl. `AHU.supplyAirTemperature → room`), per-room volumes and the transformation routing; fails on `dev`.
* `test_offline_translation.py` (SAREF one-room example) unchanged and passing; `tests/translator`, `tests/systems/{sensor,air_handling_unit,building_space,outdoor_environment,controller,fan,air_to_air_heat_recovery}`, `tests/model/semantic_model` pass on the integrated stack (255 tests, Graphviz-dependent ones excluded).
* With the whole stack the HTR case runs the two-stage workflow (12 identified PI loops → closed-loop AHU + 4 rooms) with no post-translation wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
