### PR TITLE
CI: survive a broken third-party apt list, and stop running every PR twice

### DIFF
--- a/.github/workflows/ub-py3-10.yml
+++ b/.github/workflows/ub-py3-10.yml
@@ -4,11 +4,21 @@
 name: ubuntu-python3.10
 
 on:
+  # Pull requests are covered by the pull_request event.  Without a branch
+  # filter here, every push to a PR branch ran this workflow a second time:
+  # two independent chances of hitting a transient runner failure, and two
+  # conflicting statuses for the same job name.
   push:
+    branches: [main, dev]
   pull_request:
 
 permissions:
   contents: read
+
+# A new push supersedes the run it interrupts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -29,9 +39,14 @@ jobs:
 
     - name: Install Graphviz
       run: |
-        sudo add-apt-repository universe
-        sudo apt update
-        sudo apt install graphviz
+        # The hosted image ships third-party apt lists (Google Chrome) whose
+        # index intermittently fails its hash check, and apt exits 100 when any
+        # list fails -- killing the job before a single test runs.  graphviz is
+        # in the Ubuntu archives, so drop the third-party lists and retry.
+        sudo rm -f /etc/apt/sources.list.d/*google-chrome*.list
+        sudo add-apt-repository -y universe
+        sudo apt-get update -o Acquire::Retries=3
+        sudo apt-get install -y --no-install-recommends graphviz
 
     - name: Cache pip
       uses: actions/cache@v4

--- a/.github/workflows/ub-py3-11.yml
+++ b/.github/workflows/ub-py3-11.yml
@@ -4,11 +4,21 @@
 name: ubuntu-python3.11
 
 on:
+  # Pull requests are covered by the pull_request event.  Without a branch
+  # filter here, every push to a PR branch ran this workflow a second time:
+  # two independent chances of hitting a transient runner failure, and two
+  # conflicting statuses for the same job name.
   push:
+    branches: [main, dev]
   pull_request:
 
 permissions:
   contents: read
+
+# A new push supersedes the run it interrupts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -29,9 +39,14 @@ jobs:
 
     - name: Install Graphviz
       run: |
-        sudo add-apt-repository universe
-        sudo apt update
-        sudo apt install graphviz
+        # The hosted image ships third-party apt lists (Google Chrome) whose
+        # index intermittently fails its hash check, and apt exits 100 when any
+        # list fails -- killing the job before a single test runs.  graphviz is
+        # in the Ubuntu archives, so drop the third-party lists and retry.
+        sudo rm -f /etc/apt/sources.list.d/*google-chrome*.list
+        sudo add-apt-repository -y universe
+        sudo apt-get update -o Acquire::Retries=3
+        sudo apt-get install -y --no-install-recommends graphviz
 
     - name: Cache pip
       uses: actions/cache@v4

--- a/.github/workflows/ub-py3-12.yml
+++ b/.github/workflows/ub-py3-12.yml
@@ -4,11 +4,21 @@
 name: ubuntu-python3.12
 
 on:
+  # Pull requests are covered by the pull_request event.  Without a branch
+  # filter here, every push to a PR branch ran this workflow a second time:
+  # two independent chances of hitting a transient runner failure, and two
+  # conflicting statuses for the same job name.
   push:
+    branches: [main, dev]
   pull_request:
 
 permissions:
   contents: read
+
+# A new push supersedes the run it interrupts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -29,9 +39,14 @@ jobs:
 
     - name: Install Graphviz
       run: |
-        sudo add-apt-repository universe
-        sudo apt update
-        sudo apt install graphviz
+        # The hosted image ships third-party apt lists (Google Chrome) whose
+        # index intermittently fails its hash check, and apt exits 100 when any
+        # list fails -- killing the job before a single test runs.  graphviz is
+        # in the Ubuntu archives, so drop the third-party lists and retry.
+        sudo rm -f /etc/apt/sources.list.d/*google-chrome*.list
+        sudo add-apt-repository -y universe
+        sudo apt-get update -o Acquire::Retries=3
+        sudo apt-get install -y --no-install-recommends graphviz
 
     - name: Cache pip
       uses: actions/cache@v4

--- a/.github/workflows/ub-py3-9.yml
+++ b/.github/workflows/ub-py3-9.yml
@@ -4,11 +4,21 @@
 name: ubuntu-python3.9
 
 on:
+  # Pull requests are covered by the pull_request event.  Without a branch
+  # filter here, every push to a PR branch ran this workflow a second time:
+  # two independent chances of hitting a transient runner failure, and two
+  # conflicting statuses for the same job name.
   push:
+    branches: [main, dev]
   pull_request:
 
 permissions:
   contents: read
+
+# A new push supersedes the run it interrupts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -29,9 +39,14 @@ jobs:
 
     - name: Install Graphviz
       run: |
-        sudo add-apt-repository universe
-        sudo apt update
-        sudo apt install graphviz
+        # The hosted image ships third-party apt lists (Google Chrome) whose
+        # index intermittently fails its hash check, and apt exits 100 when any
+        # list fails -- killing the job before a single test runs.  graphviz is
+        # in the Ubuntu archives, so drop the third-party lists and retry.
+        sudo rm -f /etc/apt/sources.list.d/*google-chrome*.list
+        sudo add-apt-repository -y universe
+        sudo apt-get update -o Acquire::Retries=3
+        sudo apt-get install -y --no-install-recommends graphviz
 
     - name: Cache pip
       uses: actions/cache@v4

--- a/.github/workflows/win-py3-10.yml
+++ b/.github/workflows/win-py3-10.yml
@@ -4,11 +4,21 @@
 name: windows-python3.10
 
 on:
+  # Pull requests are covered by the pull_request event.  Without a branch
+  # filter here, every push to a PR branch ran this workflow a second time:
+  # two independent chances of hitting a transient runner failure, and two
+  # conflicting statuses for the same job name.
   push:
+    branches: [main, dev]
   pull_request:
 
 permissions:
   contents: read
+
+# A new push supersedes the run it interrupts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/win-py3-11.yml
+++ b/.github/workflows/win-py3-11.yml
@@ -4,11 +4,21 @@
 name: windows-python3.11
 
 on:
+  # Pull requests are covered by the pull_request event.  Without a branch
+  # filter here, every push to a PR branch ran this workflow a second time:
+  # two independent chances of hitting a transient runner failure, and two
+  # conflicting statuses for the same job name.
   push:
+    branches: [main, dev]
   pull_request:
 
 permissions:
   contents: read
+
+# A new push supersedes the run it interrupts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/win-py3-12.yml
+++ b/.github/workflows/win-py3-12.yml
@@ -4,11 +4,21 @@
 name: windows-python3.12
 
 on:
+  # Pull requests are covered by the pull_request event.  Without a branch
+  # filter here, every push to a PR branch ran this workflow a second time:
+  # two independent chances of hitting a transient runner failure, and two
+  # conflicting statuses for the same job name.
   push:
+    branches: [main, dev]
   pull_request:
 
 permissions:
   contents: read
+
+# A new push supersedes the run it interrupts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/win-py3-9.yml
+++ b/.github/workflows/win-py3-9.yml
@@ -4,11 +4,21 @@
 name: windows-python3.9
 
 on:
+  # Pull requests are covered by the pull_request event.  Without a branch
+  # filter here, every push to a PR branch ran this workflow a second time:
+  # two independent chances of hitting a transient runner failure, and two
+  # conflicting statuses for the same job name.
   push:
+    branches: [main, dev]
   pull_request:
 
 permissions:
   contents: read
+
+# A new push supersedes the run it interrupts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
## What fails and why

Most open PRs show red CI for reasons unrelated to their changes.

**1. `apt update` exits 100 on a third-party list.** The Ubuntu jobs install graphviz with

```
sudo add-apt-repository universe
sudo apt update
sudo apt install graphviz
```

`apt update` returns exit 100 when *any* configured list fails to fetch. The GitHub-hosted image ships a Google Chrome apt list whose index intermittently fails its hash check:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
E: Some index files failed to download.
##[error]Process completed with exit code 100.
```

The job then dies in 12 to 40 seconds, before a single test runs. graphviz lives in the Ubuntu archives, so this drops the third-party lists first, retries the fetch, and installs non-interactively.

**2. Every PR runs the whole matrix twice.** All eight workflows trigger on both `push` (no branch filter) and `pull_request`, so each push to a PR branch starts sixteen runs. That gives two independent chances of hitting a transient runner failure and two conflicting statuses for the same job name, which is exactly the confusing pattern on the open PRs: `Test Ubuntu (3.10) fail 14s` next to `Test Ubuntu (3.10) pass 48m`. Jobs take 30 to 60 minutes each, so this also duplicated roughly 13 hours of runner time per push.

`push` is now limited to `main` and `dev`, and a concurrency group cancels a run that a newer push supersedes.

## Not covered here

- PR #163 replaces these eight files with a single `ci.yml`, which has the same bare `apt-get update`. It needs the same two-line fix on its own branch, or after it merges.
- Genuine test failures on #152, #162 and #166 are unaffected by this and still need code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)