### PR TITLE
feat: model a room radiator from a BRICK Heating_Command (#169)

### DIFF
--- a/twin4build/systems/building_space/building_space_system.py
+++ b/twin4build/systems/building_space/building_space_system.py
@@ -544,6 +544,12 @@ def _brick_space_pattern(topology: str, with_volume: bool):
     outside_air_temperature_sensor = Node(
         cls=core.namespace.BRICK.Outside_Air_Temperature_Sensor
     )
+    # Room-level radiator: BMS graphs carry only a valve command on the room
+    # (no radiator equipment).  When a :class:`SpaceHeaterSystem` is matched
+    # there (see its ``brick_signature_pattern_room_heating_command``), its
+    # delivered ``Power`` is the room's ``heatGain``.  Optional, so rooms
+    # without heating still match.
+    heating_cmd = Node(cls=core.namespace.BRICK.Heating_Command)
     feeds = Predicate((core.namespace.BRICK.feeds, core.namespace.FSO.feedsFluidTo))
 
     suffix = "_with_volume" if with_volume else ""
@@ -593,6 +599,12 @@ def _brick_space_pattern(topology: str, with_volume: bool):
     sp.add_connection(
         outside_air_temperature_sensor, "outdoorTemperature", "outdoorTemperature"
     )
+    sp.add_rule(
+        OptionalRule(
+            subject=space, object=heating_cmd, predicate=core.namespace.BRICK.hasPoint
+        )
+    )
+    sp.add_connection(heating_cmd, "Power", "heatGain")
     if with_volume:
         _add_brick_volume_parameter(sp, space)
     # Interzonal/boundary coupling is modeled by a separate WallSystem

--- a/twin4build/systems/space_heater/space_heater_system.py
+++ b/twin4build/systems/space_heater/space_heater_system.py
@@ -19,6 +19,7 @@ from twin4build.translator.translator import (
     StepRule,
     AnyPathRule,
     Node,
+    ModeledNode,
     OptionalRule,
     SignaturePattern,
     PathRule,
@@ -728,6 +729,63 @@ def brick_signature_pattern():
     return sp
 
 
+def brick_signature_pattern_room_heating_command():
+    """BRICK pattern for a radiator driven by a room-level heating command.
+
+    BMS-derived graphs often carry no radiator equipment, no water-flow
+    sensor and no supply-temperature point: the only heating information on
+    a room is a valve command (Hoeje-Taastrup Raadhus: ``R08_01_MVV01``, a
+    ``brick:Heating_Command`` in percent).  This pattern models one space
+    heater per such command::
+
+        Room  hasPoint  Heating_Command   -> waterFlowRate  (valve command)
+        Room                              -> indoorTemperature
+
+    ``waterFlowRate`` is fed from the command's historised
+    :class:`SensorSystem` (the leaf pattern matches the same point), so the
+    caller supplies the percent -> kg/s conversion through
+    :meth:`Model.set_transformations` (a ``brick:Heating_Command`` rule)
+    and the nominal water temperature through
+    :meth:`Model.fill_missing_inputs` (``supplyWaterTemperature``); both are
+    site data the ontology does not carry.  ``UA`` and
+    ``thermalMassHeatCapacity`` are then estimable per room.
+
+    The delivered ``Power`` is consumed by the room: the BRICK building-space
+    patterns bind the same ``Heating_Command`` node and connect
+    ``Power -> heatGain`` (see
+    :func:`twin4build.systems.building_space.building_space_system._brick_space_pattern`).
+
+    The modeled identity is the multi-member group ``[space, heating_cmd]``:
+    multi-member groups are mutex-ed per fingerprint, so this component can
+    coexist with the :class:`BuildingSpaceSystem` modeled on ``space`` and
+    with the leaf :class:`SensorSystem` modeled on the command.
+    """
+    space = Node(
+        cls=(
+            core.namespace.BRICK.Room,
+            core.namespace.BRICK.HVAC_Zone,
+            core.namespace.BRICK.Enclosed_space,
+            core.namespace.BRICK.Open_space,
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
+            core.namespace.BRICK.Space,
+        )
+    )
+    heating_cmd = Node(cls=core.namespace.BRICK.Heating_Command)
+
+    sp = SignaturePattern(id="space_heater_signature_pattern_brick_room_command")
+    sp.add_rule(
+        StepRule(
+            subject=space, object=heating_cmd, predicate=core.namespace.BRICK.hasPoint
+        )
+    )
+    sp.add_connection(heating_cmd, "measuredValue", "waterFlowRate")
+    sp.add_connection(space, "indoorTemperature", "indoorTemperature")
+    ModeledNode([space, heating_cmd])
+    return sp
+
+
+SpaceHeaterSystem.add_signature_pattern(brick_signature_pattern_room_heating_command())
 SpaceHeaterSystem.add_signature_pattern(brick_signature_pattern())
 SpaceHeaterSystem.add_signature_pattern(saref_signature_pattern())
 

--- a/twin4build/tests/translator/test_brick14_bms_patterns.py
+++ b/twin4build/tests/translator/test_brick14_bms_patterns.py
@@ -191,10 +191,15 @@ class TestBrick14BmsPatterns(unittest.TestCase):
             downstream = _outgoing_components(cits, "inputSignal")
             self.assertTrue(any(isinstance(c, SensorSystem) for c in downstream))
         self.assertEqual(sorted(gates), ["R01_SpFCI01_C", "R02_SpFCI01_C", "R02_SpFCI02_C"])
-        # ... and the AHU damper slot of each room is driven by exactly one
-        # of that room's controllers (one connection per Vector slot).
-        drivers = [c for c in cits_list if ahu in _outgoing_components(c, "inputSignal")]
-        self.assertEqual(len(drivers), 2)
+        # ... and each AHU damper Vector gets exactly one input per room slot,
+        # sourced from a controller.  Which VAV of a room drives which of the
+        # two damper vectors is up to the MILP, so only the per-slot
+        # invariant is asserted.
+        for port in ("supplyDamperPosition", "exhaustDamperPosition"):
+            sources = incoming(ahu, port)
+            self.assertEqual(len(sources), 2, port)  # one per room
+            for src in sources:
+                self.assertIsInstance(src, ControllerIdentificationPISystem)
 
         outdoor = by_cls["OutdoorEnvironmentSystem"][0]
         self.assertEqual(outdoor.uuid_outdoorTemperature, "WS01_TOUT")

--- a/twin4build/tests/translator/test_space_heater_room_command.py
+++ b/twin4build/tests/translator/test_space_heater_room_command.py
@@ -1,0 +1,125 @@
+"""Room-level radiator from a BRICK ``Heating_Command``.
+
+BMS-derived graphs often carry no radiator equipment, no water-flow sensor
+and no supply-temperature point: the only heating information on a room is a
+valve command (Hoeje-Taastrup Raadhus: ``R08_01_MVV01``).  The pattern under
+test turns that into one :class:`SpaceHeaterSystem` per room, fed by the
+command's historised sensor, and the delivered ``Power`` becomes the room's
+``heatGain``.
+"""
+
+# Standard library imports
+import os
+import shutil
+import unittest
+
+# Third party imports
+from rdflib import RDF, BNode, Literal, Namespace
+
+# Local application imports
+import twin4build
+import twin4build.core as core
+from twin4build.model.semantic_model.semantic_model import SemanticModel
+from twin4build.systems.air_handling_unit.air_handling_unit_system import (
+    AirHandlingUnitSystem,
+)
+from twin4build.systems.building_space.building_space_system import (
+    BuildingSpaceSystem,
+)
+from twin4build.systems.sensor.sensor_system import SensorSystem
+from twin4build.systems.space_heater.space_heater_system import SpaceHeaterSystem
+from twin4build.translator.translator import Translator
+
+twin4build._IS_TESTING = True
+
+BRICK = core.namespace.BRICK
+REC = core.namespace.REC
+REF = core.namespace.BRICKREF
+EX = Namespace("http://example.org/heating#")
+
+
+def _point(g, owner, name, cls):
+    p = EX[name]
+    g.add((owner, BRICK.hasPoint, p))
+    g.add((p, RDF.type, cls))
+    ref = BNode()
+    g.add((p, REF.hasExternalReference, ref))
+    g.add((ref, RDF.type, REF.TimeseriesReference))
+    g.add((ref, REF.hasTimeseriesId, Literal(name)))
+    return p
+
+
+def _graph(sm):
+    """Two rooms served by one AHU; only R01 has a radiator valve command."""
+    g = sm.instance_graph
+    g.add((EX.AHU01, RDF.type, BRICK.AHU))
+    for i in (1, 2):
+        room, vav = EX[f"R0{i}"], EX[f"R0{i}_VAV01"]
+        g.add((room, RDF.type, REC.Room))
+        g.add((vav, RDF.type, BRICK.VAV))
+        g.add((EX.AHU01, BRICK.feeds, vav))
+        g.add((vav, BRICK.feeds, room))
+        _point(g, vav, f"R0{i}_VAV01_CMD", BRICK.Damper_Position_Command)
+        _point(g, room, f"R0{i}_TRU01", BRICK.Zone_Air_Temperature_Sensor)
+    _point(g, EX["R01"], "R01_MVV01", BRICK.Heating_Command)
+
+
+def _incoming(component, port):
+    for cp in component.connects_at:
+        if cp.input_port == port:
+            return [conn.connects_system for conn in cp.connects_system_through]
+    return []
+
+
+class TestSpaceHeaterFromRoomHeatingCommand(unittest.TestCase):
+    MODEL_ID = "test_space_heater_room_command"
+
+    def tearDown(self):
+        path = os.path.join("generated_files", "models", self.MODEL_ID)
+        if os.path.exists(path):
+            shutil.rmtree(path)
+
+    def test_radiator_is_wired_to_room_and_command(self):
+        sm = SemanticModel(id=self.MODEL_ID, namespaces={"ex": str(EX)})
+        _graph(sm)
+        model = Translator().translate(
+            sm,
+            systems=[
+                BuildingSpaceSystem,
+                AirHandlingUnitSystem,
+                SpaceHeaterSystem,
+                SensorSystem,
+            ],
+            id=self.MODEL_ID,
+        )
+        heaters = model.get_components_by_class(SpaceHeaterSystem)
+        rooms = model.get_components_by_class(BuildingSpaceSystem)
+        self.assertEqual(len(rooms), 2)
+        # Only the room carrying a Heating_Command gets a radiator.
+        self.assertEqual(len(heaters), 1)
+        heater = heaters[0]
+
+        # Water side: the valve command's historised sensor (percent ->
+        # kg/s is a caller-side transformation, see Model.set_transformations).
+        flow_sources = _incoming(heater, "waterFlowRate")
+        self.assertEqual([type(c).__name__ for c in flow_sources], ["SensorSystem"])
+        self.assertEqual(flow_sources[0].uuid, "R01_MVV01")
+
+        # Air side: the room it heats, and the heat goes back into that room.
+        (room_in,) = _incoming(heater, "indoorTemperature")
+        self.assertIsInstance(room_in, BuildingSpaceSystem)
+        heated = [r for r in rooms if heater in _incoming(r, "heatGain")]
+        self.assertEqual(heated, [room_in])
+
+        # The room without a command keeps an unwired heatGain, so
+        # ``fill_missing_inputs`` can still supply a constant there.
+        unheated = [r for r in rooms if r is not room_in]
+        self.assertEqual(_incoming(unheated[0], "heatGain"), [])
+
+        # ``supplyWaterTemperature`` is not in the graph; it stays unwired for
+        # ``fill_missing_inputs``.
+        self.assertEqual(_incoming(heater, "supplyWaterTemperature"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #169

Stacked on #162 (needs the BRICK building-space pattern factory and the REC location classes); base is that branch.

## Summary
New `space_heater_signature_pattern_brick_room_command` on `SpaceHeaterSystem`:

```
Room  hasPoint  Heating_Command  -> SpaceHeaterSystem.waterFlowRate
Room                             -> SpaceHeaterSystem.indoorTemperature
SpaceHeaterSystem.Power          -> BuildingSpaceSystem.heatGain
```

* The two quantities the ontology does not carry stay caller-side and generic: percent -> kg/s through `Model.set_transformations` (a `brick:Heating_Command` rule) and the supply water temperature through `Model.fill_missing_inputs`. `UA` and `thermalMassHeatCapacity` are estimated per room.
* Modeled identity is the multi-member group `[space, heating_cmd]`, so the radiator coexists with the `BuildingSpaceSystem` modeled on the room and the leaf `SensorSystem` modeled on the command.
* The `Power -> heatGain` edge is an optional node on the BRICK building-space patterns (`_brick_space_pattern`), so rooms without a heating command are untouched and `fill_missing_inputs` still supplies a constant there.

## Test plan
* New `tests/translator/test_space_heater_room_command.py`: two rooms, one with a heating command; asserts exactly one radiator, its water side wired to the command's historised sensor, its air side to the room it heats, `Power -> heatGain` on that room only, and `supplyWaterTemperature` left unwired for `fill_missing_inputs`.
* `test_brick14_bms_patterns.py` passes; one assertion in it is relaxed to the real invariant (which VAV of a multi-VAV room drives which damper Vector is a MILP tie-break, so it now checks one input per room slot per vector rather than a controller count).

## Effect on the HTR case
Zone-temperature RMSE after two SLSQP iterations of the Stage 2 physics fit, HTR9_VEN02, 4-10 March 2024:

| room | radiator use in the window | before | after |
|---|---|---|---|
| R08.01 | valve open 107 of 144 h, modulating 0-100 % | 13.3 K | 2.7 K |
| R08.06_n / _o / R08.07 | valve open < 5 h, mean < 0.5 % | 13.8 K | 11.2-12.2 K |

The three rooms whose valves stay shut are unchanged, as expected: they are warm because of neighbours and gains, not their own radiator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
