### PR TITLE
feat: composable ControllerIdentificationSystem (pure forward) and later-producer feedback in the composer (#171)

### DIFF
--- a/twin4build/simulator/_composed.py
+++ b/twin4build/simulator/_composed.py
@@ -397,9 +397,17 @@ class OneStepComposer:
         return None
 
     def _influence_cone(self, seed_extra=()) -> List:
-        """Forward-components reverse-reachable (over fresh edges, following
-        pass-through sensors) from the stateful components -- plus any extra
-        seed ids (requested-output producers) -- in execution order."""
+        """Forward-components reverse-reachable (following pass-through
+        sensors) from the stateful components -- plus any extra seed ids
+        (requested-output producers) -- in execution order.
+
+        Producers that execute *later* than their consumer are included too:
+        their edge is the cut of a cycle, so the consumer reads the previous
+        step's value (``do_step``'s Gauss-Seidel lag) and
+        :meth:`_classify_source` threads it as a feedback lag variable.
+        Leaving such a producer out would freeze a theta-dependent signal
+        into a captured constant (e.g. a stateless AHU that executes after
+        the zones it feeds, driven by controllers that read the zones)."""
         keep = set(c.id for c in self.stateful) | set(seed_extra)
         changed = True
         while changed:
@@ -416,11 +424,7 @@ class OneStepComposer:
                         src = self._trace_source(c, port)
                         srcs = [src] if src is not None else []
                     for prod, _ in srcs:
-                        if (
-                            prod.id in self.forward_ids
-                            and self.pos[prod.id] < self.pos[c.id]
-                            and prod.id not in keep
-                        ):
+                        if prod.id in self.forward_ids and prod.id not in keep:
                             keep.add(prod.id)
                             changed = True
         return [c for c in self.order if c.id in keep and c.id in self.forward_ids]

--- a/twin4build/systems/controller/controller_identification/controller_identification_system.py
+++ b/twin4build/systems/controller/controller_identification/controller_identification_system.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 # Local application imports
 import twin4build.core as core
 import twin4build.utils.types as tps
+from twin4build.utils.rgetattr import rgetattr
 from twin4build.systems.controller.rulebased_controller.sat_compensated_controller.sat_compensated_controller_system import (
     SATCompensatedControllerSystem,
 )
@@ -475,7 +476,24 @@ class ControllerIdentificationSystem(core.System, nn.Module):
                     for param in ctrl._config["parameters"]:
                         config_params.append(f"candidate_{a}_{c}.{param}")
         self._config = {"parameters": config_params}
-
+        # ``forward`` theta contract: every tunable the pure step reads, keyed
+        # by the attribute path ``_forward_params`` / the composer resolve via
+        # ``rgetattr`` (selection weights, gate parameters, candidate gains).
+        names: List[str] = []
+        for a in range(n_actuators):
+            names += [f"alpha_{a}", f"beta_{a}", f"gamma_{a}"]
+            if self._has_cascade:
+                names.append(f"beta_b_{a}")
+            names += [f"gamma_gate_{a}", f"alpha_gate_{a}", f"default_output_{a}"]
+            gate = getattr(self, f"gate_{a}")
+            names += [f"gate_{a}.{n}" for n in getattr(gate, "PARAM_NAMES", ())]
+            for c in range(self.n_candidates):
+                ctrl = getattr(self, f"candidate_{a}_{c}")
+                names += [
+                    f"candidate_{a}_{c}.{n}" for n in getattr(ctrl, "PARAM_NAMES", ())
+                ]
+        self.PARAM_NAMES = tuple(names)
+        self._state_slices = None
         self._built = True
 
     @property
@@ -814,7 +832,10 @@ class ControllerIdentificationSystem(core.System, nn.Module):
         # Initialize gate sub-systems
         for a in range(self.n_actuators):
             self._get_gate(a).initialize(start_time, end_time, step_size)
-
+        # Identity-stable sample time for ``forward``'s coefficient caches
+        # (the candidates key their caches on the sample-time object).
+        self._sample_time = self._scalar_sample_time(step_size)
+        self._state_slices = self._compute_state_slices()
         self.INITIALIZED = True
 
     def _compute_weighted_signals(self, actuator: int) -> Tuple[torch.Tensor, ...]:
@@ -866,95 +887,176 @@ class ControllerIdentificationSystem(core.System, nn.Module):
         step_size: int,
         step_index: int,
     ) -> None:
-        """Perform one simulation step.
+        """Thin port-I/O wrapper around :meth:`forward` (the single source of
+        truth for the identification math: weighted signals, candidate
+        controllers, alpha blending and the on/off gate)."""
+        inputs = {
+            "sensorValue": self.input["sensorValue"].get(),
+            "setpointValue": self.input["setpointValue"].get(),
+            "onOffSignal": self.input["onOffSignal"].get(),
+        }
+        x = self.get_state() if self.state_size() > 0 else None
+        x_next, outs = self.forward(
+            x, inputs, self._forward_params(), self._sample_time
+        )
+        if x_next is not None:
+            self.set_state(x_next)
+        self.output["inputSignal"].set(outs["inputSignal"], step_index)
 
-        For each actuator:
-        1. Compute per-actuator weighted setpoint and feedback signals
-        2. Run all candidate controllers with actuator-specific error signal
-        3. Combine outputs using normalized alpha weights
-        """
-        n_s = self.input["sensorValue"].n_s
-        n_c = self.input["sensorValue"].n_c
+    # -- composed-map support ------------------------------------------------
+    # Continuous state is the concatenation of the candidate controllers'
+    # ``tps.State`` memories (the order :meth:`System.get_state` produces);
+    # the gates are stateless.  ``forward`` is functorch-safe: it only reads
+    # ``params`` (never ``self.<parameter>``) and the structural attributes
+    # fixed at ``initialize`` (candidate types, state slices, gate wiring).
+    SUPPORTS_TRANSFORM_MODE = True
 
-        # Process each actuator
-        actuator_outputs = torch.zeros(n_s, n_c, self.n_actuators, dtype=tps.float_dtype())
-
+    def _compute_state_slices(self) -> Dict[Tuple[int, int], Tuple[int, int]]:
+        """``(actuator, candidate) -> (offset, width)`` into the concatenated
+        state.  Each candidate's states are contiguous in
+        :meth:`collect_states` (it recurses child by child), so the slice is
+        located by identity of the candidate's first state object."""
+        all_states = self.collect_states()
+        offsets = []
+        acc = 0
+        for st in all_states:
+            offsets.append(acc)
+            acc += int(st.n_v)
+        slices = {}
         for a in range(self.n_actuators):
-            # Compute per-actuator weighted signals (each actuator has own beta/gamma/beta_b)
-            signals = self._compute_weighted_signals(a)
-            weighted_setpoint = signals[0]
-            weighted_feedback = signals[1]
-            weighted_feedback_b = signals[2] if len(signals) > 2 else None
+            for c in range(self.n_candidates):
+                own = self._get_candidate(a, c).collect_states()
+                width = sum(int(st.n_v) for st in own)
+                if width == 0:
+                    slices[(a, c)] = (acc, 0)
+                    continue
+                first = next(i for i, st in enumerate(all_states) if st is own[0])
+                slices[(a, c)] = (offsets[first], width)
+        return slices
 
-            # Run all candidate controllers and collect outputs
+    @staticmethod
+    def _sub_params(sub, prefix: str, params: dict) -> dict:
+        """Physical-parameter dict of an owned sub-system (candidate or gate)
+        from the composite ``params`` (keys ``"<prefix>.<name>"``), falling
+        back to the sub-system's own ``tps.Parameter`` values."""
+        out = {}
+        for name in getattr(sub, "PARAM_NAMES", ()):
+            key = f"{prefix}.{name}"
+            out[name] = params[key] if key in params else rgetattr(sub, name).get()
+        return out
+
+    def _resolve_forward_params(self, params: dict, transform_mode) -> dict:
+        """Per-sub-system params dicts, identity-cached on ``params`` so the
+        candidates' own identity-keyed caches (PID coefficients) keep hitting
+        across a sequential rollout."""
+        if not transform_mode:
+            cache = getattr(self, "_fwd_sub_cache", None)
+            if cache is not None and cache[0] is params:
+                return cache[1]
+        sub = {}
+        for a in range(self.n_actuators):
+            sub[("gate", a)] = self._sub_params(self._get_gate(a), f"gate_{a}", params)
+            for c in range(self.n_candidates):
+                sub[(a, c)] = self._sub_params(
+                    self._get_candidate(a, c), f"candidate_{a}_{c}", params
+                )
+        if not transform_mode:
+            self._fwd_sub_cache = (params, sub)
+        return sub
+
+    def forward(self, x, inputs, params, sample_time, transform_mode=None):
+        """Pure one-step controller identification
+        ``(state, inputs, params) -> (new_state, outputs)``.
+
+        ``inputs`` holds the Vector ports ``sensorValue`` ``(..., n_sensors)``,
+        ``setpointValue`` ``(..., n_setpoints)`` and ``onOffSignal``
+        ``(..., n_on_off_signals)``; ``x`` the concatenated candidate memories
+        ``(..., D)`` (``None`` when every candidate is stateless); ``params``
+        a dict for :attr:`PARAM_NAMES`.  For each actuator: the beta / gamma
+        weighted feedback and setpoint drive every candidate's ``forward``,
+        the outputs are alpha-blended, and the gamma-gate weighted on/off
+        signal (normalised with the rewire-populated bounds) passes through
+        the actuator's gate.  Returns ``(x_next, {"inputSignal": (...,
+        n_actuators)})``.
+        """
+        if self._state_slices is None:
+            self._state_slices = self._compute_state_slices()
+        sub = self._resolve_forward_params(params, transform_mode)
+        sensor_values = inputs["sensorValue"]
+        setpoint_values = inputs["setpointValue"]
+        on_off = inputs["onOffSignal"]
+        oo_min = self.on_off_signal_norm_min.to(device=on_off.device, dtype=on_off.dtype)
+        oo_max = self.on_off_signal_norm_max.to(device=on_off.device, dtype=on_off.dtype)
+        on_off_norm = (on_off - oo_min) / (oo_max - oo_min).clamp(min=1e-6)
+
+        new_state_parts = []  # (offset, tensor)
+        actuator_outputs = []
+        for a in range(self.n_actuators):
+            gamma = params[f"gamma_{a}"]
+            gamma_norm = gamma / (torch.sum(gamma) + 1e-8)
+            beta = params[f"beta_{a}"]
+            beta_norm = beta / (torch.sum(beta) + 1e-8)
+            weighted_setpoint = torch.sum(gamma_norm * setpoint_values, dim=-1)
+            weighted_feedback = torch.sum(beta_norm * sensor_values, dim=-1)
+            weighted_feedback_b = None
+            if self._has_cascade:
+                beta_b = params[f"beta_b_{a}"]
+                beta_b_norm = beta_b / (torch.sum(beta_b) + 1e-8)
+                weighted_feedback_b = torch.sum(beta_b_norm * sensor_values, dim=-1)
+
             candidate_outputs = []
             for c in range(self.n_candidates):
                 ctrl = self._get_candidate(a, c)
                 ctype = self._candidate_types[c]
-
                 if ctype == self.CTRL_CASCADE:
-                    ctrl.input["setpointValue_a"].set(weighted_setpoint, step_index)
-                    ctrl.input["actualValue_a"].set(weighted_feedback, step_index)
-                    ctrl.input["actualValue_b"].set(weighted_feedback_b, step_index)
-                elif ctype == self.CTRL_SETPOINT:
-                    ctrl.input["setpointValue"].set(weighted_setpoint, step_index)
-                    ctrl.input["actualValue"].set(weighted_feedback, step_index)
-
-                ctrl.do_step(second_time, date_time, step_size, step_index)
-                candidate_outputs.append(ctrl.output["inputSignal"].get())
-
-            # Stack outputs: (n_candidates, n_s, n_c)
-            candidate_outputs = torch.stack(candidate_outputs, dim=0)
-
-            # Flatten to (n_candidates, n_s * n_c) for einsum
-            orig_shape = candidate_outputs.shape[1:]  # (n_s, n_c) or similar
-            candidate_outputs_flat = candidate_outputs.reshape(self.n_candidates, -1)
-
-            # Ratio-normalised weighted sum of candidate outputs
-            alpha = self._get_alpha_vector(a)
+                    ctrl_inputs = {
+                        "setpointValue_a": weighted_setpoint,
+                        "actualValue_a": weighted_feedback,
+                        "actualValue_b": weighted_feedback_b,
+                    }
+                else:
+                    ctrl_inputs = {
+                        "setpointValue": weighted_setpoint,
+                        "actualValue": weighted_feedback,
+                    }
+                offset, width = self._state_slices[(a, c)]
+                x_c = x[..., offset : offset + width] if (x is not None and width) else None
+                kwargs = (
+                    {"transform_mode": transform_mode}
+                    if getattr(ctrl, "SUPPORTS_TRANSFORM_MODE", False)
+                    else {}
+                )
+                x_c_next, out_c = ctrl.forward(
+                    x_c, ctrl_inputs, sub[(a, c)], sample_time, **kwargs
+                )
+                if width:
+                    new_state_parts.append((offset, x_c_next))
+                candidate_outputs.append(out_c["inputSignal"])
+            stacked = torch.stack(candidate_outputs, dim=0)  # (n_cand, ...)
+            alpha = params[f"alpha_{a}"]
             alpha_norm = alpha / (torch.sum(alpha) + 1e-8)
-            combined_output = torch.einsum(
-                "c,cb->b", alpha_norm, candidate_outputs_flat
-            )
+            combined = torch.einsum("c,c...->...", alpha_norm, stacked)
 
-            # Reshape back
-            combined_output = combined_output.reshape(orig_shape)
-
-            # On/off-signal-based gating with default output.  The gate
-            # input bus (``onOffSignal``) is structurally distinct from
-            # the PI-error setpoint bus (``setpointValue``), so the
-            # rewire pipeline can prune the latter without mutating the
-            # former.  Each onOffSignal slot is first mapped to a
-            # unit-free ``[0, 1]`` range using per-slot min/max bounds
-            # (populated from data by
-            # ``_populate_on_off_signal_norm_bounds`` -- defaults to
-            # identity).  This decouples the gate threshold/band x0
-            # from physical units so the same seed (e.g.,
-            # ``threshold=0.1, band=0.8``) can be used across rooms /
-            # signal types without manual tuning.
-            on_off_signal_values = self.input["onOffSignal"].get()  # (n_s, n_c, n_on_off_signals)
-            oo_range = (
-                self.on_off_signal_norm_max - self.on_off_signal_norm_min
-            ).clamp(min=1e-6)
-            on_off_signal_values_norm = (
-                on_off_signal_values - self.on_off_signal_norm_min
-            ) / oo_range
-            gamma_gate = self._get_gamma_gate_vector(a)
+            gamma_gate = params[f"gamma_gate_{a}"]
             gamma_gate_norm = gamma_gate / (torch.sum(gamma_gate) + 1e-8)
-            gate_input = torch.sum(
-                gamma_gate_norm * on_off_signal_values_norm, dim=-1
+            gate_input = torch.sum(gamma_gate_norm * on_off_norm, dim=-1)
+            gate = self._get_gate(a)
+            _, gate_out = gate.forward(
+                None, {gate.INPUT_PORT: gate_input}, sub[("gate", a)], sample_time
             )
+            gate_signal = gate_out[gate.OUTPUT_PORT]
+            alpha_g = params[f"alpha_gate_{a}"]
+            g = (1 - alpha_g) + alpha_g * gate_signal
+            default_out = params[f"default_output_{a}"]
+            actuator_outputs.append(g * combined + (1 - g) * default_out)
 
-            gate_signal = self._get_gate(a).compute_gate(gate_input)
-
-            alpha_g = self._get_alpha_gate(a)
-            gate = (1 - alpha_g) + alpha_g * gate_signal
-
-            default_out = self._get_default_output(a)
-            actuator_outputs[..., a] = gate * combined_output + (1 - gate) * default_out
-
-        # Set final output - shape (n_s, n_c, n_actuators)
-        self.output["inputSignal"].set(actuator_outputs, step_index)
+        output = torch.stack(actuator_outputs, dim=-1)
+        if new_state_parts:
+            new_state_parts.sort(key=lambda t: t[0])
+            x_next = torch.cat([t for _, t in new_state_parts], dim=-1)
+        else:
+            x_next = x
+        return x_next, {"inputSignal": output}
 
     def compute_binarization_penalty(self) -> torch.Tensor:
         """Compute binarization penalty P(x) = x(1-x) for all selection weights.

--- a/twin4build/tests/estimator/test_fast_shooting_later_producer.py
+++ b/twin4build/tests/estimator/test_fast_shooting_later_producer.py
@@ -1,0 +1,123 @@
+"""A stateless composable producer that executes AFTER its consumer (the cut
+edge of a cycle) must be part of the composed map's influence cone.
+
+Regression: ``OneStepComposer._influence_cone`` only followed producers that
+execute *earlier* than the consumer, so a stateless component on the cut edge
+-- e.g. an AHU ordered after the zones it feeds, driven by controllers that
+read those zones -- was frozen into a captured constant, and the composer then
+(correctly) refused the model because that constant depends on theta.  The
+consumer reads the previous step's value there (Gauss-Seidel lag), which is
+exactly the feedback lag variable the composer already threads for stateful
+producers.
+"""
+
+# Standard library imports
+import datetime
+import unittest
+from zoneinfo import ZoneInfo
+
+# Third party imports
+import numpy as np
+import pandas as pd
+import torch
+
+# Local application imports
+import twin4build
+import twin4build as tb
+
+twin4build._IS_TESTING = True
+
+START = datetime.datetime(2024, 3, 4, tzinfo=ZoneInfo("Europe/Copenhagen"))
+STEP = 600
+
+
+def build_loop():
+    """PID (stateful) -> gate (stateless plant) -> PID feedback."""
+    model = tb.Model(id="test_later_producer")
+    pid = tb.PIDControllerSystem(kp=1.0, Ti=1800.0, Td=0.0, is_reverse=False, id="pid")
+    plant = tb.SigmoidGate(threshold=0.4, steepness=6.0, id="plant")
+    setpoint = tb.ScheduleSystem(
+        weekday_ruleset={
+            "ruleset_default_value": 0.3,
+            "ruleset_start_minute": [0],
+            "ruleset_end_minute": [0],
+            "ruleset_start_hour": [8],
+            "ruleset_end_hour": [16],
+            "ruleset_value": [0.7],
+        },
+        id="setpoint",
+    )
+    model.add_connection(setpoint, pid, "scheduleValue", "setpointValue")
+    model.add_connection(pid, plant, "inputSignal", "inputSignal")
+    model.add_connection(plant, pid, "outputSignal", "actualValue")
+    sensor = tb.SensorSystem(id="plant_sensor")
+    model.add_connection(plant, sensor, "outputSignal", "measuredValue")
+    model.load(draw_semantic_model=False, draw_simulation_model=False)
+    return model, pid, plant, sensor
+
+
+class TestLaterProducerInCone(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model, cls.pid, cls.plant, cls.sensor = build_loop()
+        end = START + datetime.timedelta(hours=24)
+        sim = tb.Simulator(cls.model, execution_mode="composed")
+        sim.simulate(start_time=[START], end_time=[end], step_size=STEP, show_progress_bar=False)
+        y = cls.plant.output["outputSignal"].history().detach().flatten().numpy()
+        index = pd.date_range(start=START, periods=len(y), freq=f"{STEP}s")
+        cls.sensor.df = pd.DataFrame({"value": y + 0.01 * np.random.default_rng(0).standard_normal(len(y))}, index=index)
+        cls.estimator = tb.Estimator(tb.Simulator(cls.model, execution_mode="composed"))
+        cls.estimator.estimate(
+            parameters=[(cls.pid, "kp", 1.0, 0.1, 10.0)],
+            measurements=[(cls.sensor, 0.05)],
+            start_time=[START],
+            end_time=[end],
+            step_size=STEP,
+            n_warmup=3,
+            method=("scipy", "SLSQP", "ad"),
+            options={"maxiter": 1},
+        )
+
+    def test_plant_is_composed_whatever_the_cut(self):
+        fast = self.estimator._fast_obj
+        self.assertIsNotNone(fast, "loop through a stateless later producer did not compose")
+        composer = fast.composer
+        self.assertIn(self.plant.id, {c.id for c in composer.cone})
+        # Whichever edge the cycle cut removed, the plant's output (a
+        # composable, theta-dependent signal) must not have been frozen:
+        # captured keys are (consumer, port), so only the schedule-fed
+        # setpoint may appear for the PID.
+        self.assertNotIn((self.pid.id, "actualValue"), composer._captured_keys)
+        self.assertNotIn((self.plant.id, "inputSignal"), composer._captured_keys)
+        if composer.pos[self.plant.id] > composer.pos[self.pid.id]:
+            # The cut fell on plant -> pid: the plant is a LATER producer and
+            # must be threaded as a feedback lag variable.
+            self.assertEqual(len(composer._feedback_keys), 1)
+
+    def test_value_and_gradient_parity(self):
+        est = self.estimator
+        fast = est._fast_obj
+
+        def ev(theta, use_fast):
+            est._fast_obj = fast if use_fast else None
+            est._mse_scaled = 1.0
+            try:
+                z = torch.tensor(theta, dtype=torch.float64, requires_grad=True)
+                f = est._obj(z, "scalar")
+                (g,) = torch.autograd.grad(f, z)
+                return float(f.detach()), g.numpy()
+            finally:
+                est._fast_obj = fast
+                est._mse_scaled = None
+
+        x0 = np.asarray(est._x0_norm, dtype=np.float64)
+        for theta in (x0, np.clip(x0 + 0.15, est._lb_norm, est._ub_norm)):
+            f_slow, g_slow = ev(theta, False)
+            f_fast, g_fast = ev(theta, True)
+            self.assertLess(abs(f_fast - f_slow) / max(1e-12, abs(f_slow)), 1e-6)
+            gscale = max(1e-12, float(np.abs(g_slow).max()))
+            self.assertLess(float(np.abs(g_fast - g_slow).max()) / gscale, 1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/twin4build/tests/systems/controller/controller_identification/test_cits_forward.py
+++ b/twin4build/tests/systems/controller/controller_identification/test_cits_forward.py
@@ -1,0 +1,258 @@
+"""``ControllerIdentificationSystem`` is composable: ``do_step`` delegates to a
+pure ``forward`` (single source of truth), so a closed loop that runs through
+a CITS controller can be threaded by the composed-map engine
+(``Simulator(execution_mode="composed")``, fast single-shooting, batched GPU
+shooting).
+
+Two guards:
+
+* ``do_step`` reproduces the pre-``forward`` algorithm exactly (weighted
+  signals, candidate ``do_step``s, alpha blending, on/off gate) -- checked
+  against a verbatim re-implementation of that algorithm on an identical
+  twin instance, for the PI subclass and for the generic class with a
+  cascade candidate;
+* a closed-loop model (CITS -> plant -> CITS feedback) composes, and the fast
+  single-shooting objective matches the object-graph objective in value and
+  gradient with a candidate gain as theta.
+"""
+
+# Standard library imports
+import datetime
+import unittest
+from zoneinfo import ZoneInfo
+
+# Third party imports
+import numpy as np
+import pandas as pd
+import torch
+
+# Local application imports
+import twin4build
+import twin4build as tb
+import twin4build.utils.types as tps
+from twin4build.systems.controller.controller_identification.controller_identification_pi_system import (
+    ControllerIdentificationPISystem,
+)
+from twin4build.systems.controller.controller_identification.controller_identification_system import (
+    ControllerIdentificationSystem,
+)
+
+twin4build._IS_TESTING = True
+
+TZ = ZoneInfo("Europe/Copenhagen")
+START = datetime.datetime(2024, 3, 4, tzinfo=TZ)
+STEP = 600
+
+
+def _legacy_step(cits, step_index):
+    """The pre-``forward`` ``do_step`` algorithm, verbatim, driving the
+    candidates through their own ``do_step``."""
+    n_s = cits.input["sensorValue"].n_s
+    n_c = cits.input["sensorValue"].n_c
+    actuator_outputs = torch.zeros(n_s, n_c, cits.n_actuators, dtype=tps.float_dtype())
+    for a in range(cits.n_actuators):
+        signals = cits._compute_weighted_signals(a)
+        weighted_setpoint, weighted_feedback = signals[0], signals[1]
+        weighted_feedback_b = signals[2] if len(signals) > 2 else None
+        candidate_outputs = []
+        for c in range(cits.n_candidates):
+            ctrl = cits._get_candidate(a, c)
+            if cits._candidate_types[c] == cits.CTRL_CASCADE:
+                ctrl.input["setpointValue_a"].set(weighted_setpoint, step_index)
+                ctrl.input["actualValue_a"].set(weighted_feedback, step_index)
+                ctrl.input["actualValue_b"].set(weighted_feedback_b, step_index)
+            else:
+                ctrl.input["setpointValue"].set(weighted_setpoint, step_index)
+                ctrl.input["actualValue"].set(weighted_feedback, step_index)
+            ctrl.do_step(step_index * STEP, START, STEP, step_index)
+            candidate_outputs.append(ctrl.output["inputSignal"].get())
+        candidate_outputs = torch.stack(candidate_outputs, dim=0)
+        shape = candidate_outputs.shape[1:]
+        alpha = cits._get_alpha_vector(a)
+        alpha_norm = alpha / (torch.sum(alpha) + 1e-8)
+        combined = torch.einsum(
+            "c,cb->b", alpha_norm, candidate_outputs.reshape(cits.n_candidates, -1)
+        ).reshape(shape)
+        oo = cits.input["onOffSignal"].get()
+        oo_range = (cits.on_off_signal_norm_max - cits.on_off_signal_norm_min).clamp(min=1e-6)
+        oo_norm = (oo - cits.on_off_signal_norm_min) / oo_range
+        gamma_gate = cits._get_gamma_gate_vector(a)
+        gamma_gate_norm = gamma_gate / (torch.sum(gamma_gate) + 1e-8)
+        gate_signal = cits._get_gate(a).compute_gate(torch.sum(gamma_gate_norm * oo_norm, dim=-1))
+        alpha_g = cits._get_alpha_gate(a)
+        gate = (1 - alpha_g) + alpha_g * gate_signal
+        actuator_outputs[..., a] = gate * combined + (1 - gate) * cits._get_default_output(a)
+    cits.output["inputSignal"].set(actuator_outputs, step_index)
+
+
+def _randomise_weights(cits, rng):
+    """Non-trivial selection weights / gains so the blend is exercised."""
+    for a in range(cits.n_actuators):
+        for name in ("alpha", "beta", "gamma", "gamma_gate"):
+            p = getattr(cits, f"{name}_{a}")
+            p.set(torch.tensor(rng.uniform(0.2, 0.9, size=p.get().shape), dtype=tps.float_dtype()), normalized=False)
+        getattr(cits, f"alpha_gate_{a}").set(torch.tensor(0.7, dtype=tps.float_dtype()), normalized=False)
+        getattr(cits, f"default_output_{a}").set(torch.tensor(0.3, dtype=tps.float_dtype()), normalized=False)
+        for c in range(cits.n_candidates):
+            ctrl = cits._get_candidate(a, c)
+            for attr, lo, hi in (("kp", 0.2, 2.0), ("Ti", 600.0, 3600.0), ("kp_a", 0.1, 1.0), ("kp_b", 0.1, 1.0)):
+                p = getattr(ctrl, attr, None)
+                if p is not None:
+                    p.set(torch.tensor(rng.uniform(lo, hi), dtype=tps.float_dtype()), normalized=False)
+
+
+class TestCitsForwardMatchesLegacyDoStep(unittest.TestCase):
+    N_STEPS = 24
+
+    def _run_pair(self, factory, seed=0):
+        rng = np.random.default_rng(seed)
+        new, legacy = factory(), factory()
+        end = START + datetime.timedelta(seconds=STEP * self.N_STEPS)
+        for cits in (new, legacy):
+            cits.initialize(start_time=[START], end_time=[end], step_size=[STEP])
+            _randomise_weights(cits, np.random.default_rng(seed))
+        n_sens, n_sp, n_oo = new.n_sensors, new.n_setpoints, new.n_on_off_signals
+        outs_new, outs_legacy = [], []
+        for k in range(self.N_STEPS):
+            sens = torch.tensor(rng.uniform(18, 26, size=(1, 1, n_sens)), dtype=tps.float_dtype())
+            sp = torch.tensor(rng.uniform(20, 24, size=(1, 1, n_sp)), dtype=tps.float_dtype())
+            oo = torch.tensor(rng.uniform(0, 1, size=(1, 1, n_oo)), dtype=tps.float_dtype())
+            for cits, outs, stepper in ((new, outs_new, None), (legacy, outs_legacy, _legacy_step)):
+                cits.input["sensorValue"].set(sens.clone(), k)
+                cits.input["setpointValue"].set(sp.clone(), k)
+                cits.input["onOffSignal"].set(oo.clone(), k)
+                if stepper is None:
+                    cits.do_step(k * STEP, START, STEP, k)
+                else:
+                    stepper(cits, k)
+                outs.append(cits.output["inputSignal"].get().detach().clone())
+        a = torch.stack(outs_new).flatten()
+        b = torch.stack(outs_legacy).flatten()
+        self.assertGreater(float(a.std()), 1e-6, "controller output should move")
+        self.assertTrue(torch.allclose(a, b, atol=1e-12, rtol=1e-12), f"max |diff| = {float((a - b).abs().max()):.3e}")
+        # The candidate memories advanced identically through both paths.
+        self.assertTrue(torch.allclose(new.get_state(), legacy.get_state(), atol=1e-12))
+
+    def test_pi_subclass(self):
+        self._run_pair(
+            lambda: ControllerIdentificationPISystem(
+                n_sensors=2, n_setpoints=2, n_on_off_signals=1, n_actuators=1, id="cits_pi"
+            )
+        )
+
+    def test_generic_with_cascade_candidate(self):
+        """Default candidate set: two PIDs and a cascade -- exercises the
+        cascade input routing and the multi-candidate state slicing."""
+        self._run_pair(
+            lambda: ControllerIdentificationSystem(
+                n_sensors=2, n_setpoints=1, n_on_off_signals=2, n_actuators=1, id="cits_generic"
+            )
+        )
+
+    def test_param_names_cover_every_tunable(self):
+        cits = ControllerIdentificationPISystem(
+            n_sensors=1, n_setpoints=1, n_on_off_signals=1, n_actuators=1, id="cits"
+        )
+        names = set(cits.PARAM_NAMES)
+        for expected in ("alpha_0", "beta_0", "gamma_0", "gamma_gate_0", "alpha_gate_0",
+                         "default_output_0", "gate_0.threshold", "candidate_0_0.kp", "candidate_0_0.Ti"):
+            self.assertIn(expected, names)
+
+
+def build_closed_loop_model():
+    """CITS -> gate (the 'plant') -> CITS feedback; theta on the PI gain."""
+    model = tb.Model(id="test_cits_closed_loop")
+    cits = ControllerIdentificationPISystem(
+        n_sensors=1, n_setpoints=1, n_on_off_signals=1, n_actuators=1, id="cits"
+    )
+    plant = tb.SigmoidGate(threshold=0.4, steepness=6.0, id="plant")
+    setpoint = tb.ScheduleSystem(
+        weekday_ruleset={
+            "ruleset_default_value": 0.3,
+            "ruleset_start_minute": [0],
+            "ruleset_end_minute": [0],
+            "ruleset_start_hour": [8],
+            "ruleset_end_hour": [16],
+            "ruleset_value": [0.7],
+        },
+        id="setpoint",
+    )
+    on_off = tb.ScheduleSystem(weekday_ruleset={"ruleset_default_value": 1.0}, id="on_off")
+    model.add_connection(setpoint, cits, "scheduleValue", "setpointValue", input_port_index=0)
+    model.add_connection(on_off, cits, "scheduleValue", "onOffSignal", input_port_index=0)
+    model.add_connection(cits, plant, "inputSignal", "inputSignal", output_port_index=0)
+    model.add_connection(plant, cits, "outputSignal", "sensorValue", input_port_index=0)
+    sensor = tb.SensorSystem(id="plant_sensor")
+    model.add_connection(plant, sensor, "outputSignal", "measuredValue")
+    model.load(draw_semantic_model=False, draw_simulation_model=False)
+    return model, cits, plant, sensor
+
+
+class TestCitsClosedLoopComposes(unittest.TestCase):
+    TOL_VALUE = 1e-6
+    TOL_GRAD = 1e-5
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model, cls.cits, cls.plant, cls.sensor = build_closed_loop_model()
+        cls.end = START + datetime.timedelta(hours=24)
+        sim = tb.Simulator(cls.model, execution_mode="composed")
+        sim.simulate(start_time=cls.start_list(), end_time=[cls.end], step_size=STEP, show_progress_bar=False)
+        y = cls.plant.output["outputSignal"].history().detach().flatten().numpy()
+        index = pd.date_range(start=START, periods=len(y), freq=f"{STEP}s")
+        rng = np.random.default_rng(0)
+        cls.sensor.df = pd.DataFrame({"value": y + 0.01 * rng.standard_normal(len(y))}, index=index)
+        cls.estimator = tb.Estimator(tb.Simulator(cls.model, execution_mode="composed"))
+        cls.estimator.estimate(
+            parameters=[(cls.cits, "candidate_0_0.kp", 1.0, 0.1, 10.0), (cls.cits, "candidate_0_0.Ti", 1800.0, 300.0, 7200.0)],
+            measurements=[(cls.sensor, 0.05)],
+            start_time=cls.start_list(),
+            end_time=[cls.end],
+            step_size=STEP,
+            n_warmup=3,
+            method=("scipy", "SLSQP", "ad"),
+            options={"maxiter": 1},
+        )
+
+    @staticmethod
+    def start_list():
+        return [START]
+
+    def _eval(self, theta_np, use_fast):
+        est = self.estimator
+        fast = est._fast_obj
+        est._fast_obj = fast if use_fast else None
+        est._mse_scaled = 1.0
+        try:
+            z = torch.tensor(theta_np, dtype=torch.float64, requires_grad=True)
+            f = est._obj(z, "scalar")
+            (g,) = torch.autograd.grad(f, z)
+            return float(f.detach()), g.numpy()
+        finally:
+            est._fast_obj = fast
+            est._mse_scaled = None
+
+    def test_fast_objective_built_and_controller_in_cone(self):
+        fast = self.estimator._fast_obj
+        self.assertIsNotNone(fast, "closed loop through the CITS did not compose")
+        cone_ids = {c.id for c in fast.composer.cone}
+        self.assertIn(self.cits.id, cone_ids)
+        self.assertIn(self.plant.id, cone_ids)
+
+    def test_value_and_gradient_parity(self):
+        est = self.estimator
+        x0 = np.asarray(est._x0_norm, dtype=np.float64)
+        lbn = np.asarray(est._lb_norm, dtype=np.float64)
+        ubn = np.asarray(est._ub_norm, dtype=np.float64)
+        rng = np.random.default_rng(1)
+        for i, theta in enumerate([x0, np.clip(x0 + 0.2 * (rng.random(x0.shape) - 0.5), lbn, ubn)]):
+            f_slow, g_slow = self._eval(theta, use_fast=False)
+            f_fast, g_fast = self._eval(theta, use_fast=True)
+            self.assertLess(abs(f_fast - f_slow) / max(1e-12, abs(f_slow)), self.TOL_VALUE, f"theta[{i}] value")
+            gscale = max(1e-12, float(np.abs(g_slow).max()))
+            self.assertLess(float(np.abs(g_fast - g_slow).max()) / gscale, self.TOL_GRAD, f"theta[{i}] gradient")
+            self.assertGreater(gscale, 1e-9, "theta must influence the objective")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #171

Stacked on #166 (`fix/cits-pi-gains-estimable`, which carries #158); base is that branch.

## What
**`ControllerIdentificationSystem` gets a pure `forward`; `do_step` is now a thin port-I/O wrapper around it** (single source of truth, the same contract as `PIDControllerSystem` / `CascadeControllerSystem` / `BuildingSpaceSystem`):

* state = concatenation of the candidate controllers' `tps.State` memories, in the order `System.get_state` produces (slices located by identity at `initialize`);
* `PARAM_NAMES` = selection weights (`alpha_a`, `beta_a`, `gamma_a`, `beta_b_a`, `gamma_gate_a`, `alpha_gate_a`, `default_output_a`), the gate parameters (`gate_a.<name>`) and the candidate gains (`candidate_a_c.<name>`), dotted paths resolved with `rgetattr` exactly like the cascade controller;
* `forward` computes the beta / gamma weighted feedback and setpoint, runs every candidate's own `forward` (PID velocity form, cascade), alpha-blends the outputs, and applies the on/off gate (gamma-gate weighted, normalised with the rewire-populated bounds) -- reading only `params`, never `self.<parameter>`;
* `SUPPORTS_TRANSFORM_MODE = True`; sub-parameter dicts are identity-cached on `params` so the PID coefficient caches keep hitting across a rollout.

**`OneStepComposer._influence_cone` also pulls in forward-producers that execute *after* their consumer** (the cut edge of a cycle). The consumer reads the previous step's value there, which `_classify_source` already threads as a feedback lag variable for producers inside the cone; a producer left outside was frozen into a captured constant and, being theta-dependent, made the composer refuse the model. The HTR Stage 2 loop (zones -> sensors -> CITS -> AHU -> zones, AHU last in the execution order) hit exactly that.

## Why
Stage 2 of the two-stage workflow (identified PI-CITS controllers driving the AHU dampers) could not use any fast path: not the fast single-shooting objective, not the batched / CUDA-graph shooting backend, not collocation. On the Hoeje-Taastrup Raadhus 4-zone / 12-controller model the object-graph SLSQP costs ~5 s per iteration on the CPU.

After this PR the model composes with the zones and radiators as theta (the AHU's per-branch damper parameters are `n_c > 1` and stay out of theta -- a separate limitation of `_composer_theta_spec`), and `method=("custom", "batched-sqp", "ad")` on CUDA accepts it.

## Tests
* `tests/systems/controller/controller_identification/test_cits_forward.py`
  * `do_step` reproduces the pre-`forward` algorithm bit-for-bit (`atol=1e-12`) on a twin instance driven by the same random inputs for 24 steps, including the advanced candidate memories -- for the PI subclass and for the generic class with two PIDs and a cascade candidate (cascade routing, multi-candidate state slicing);
  * `PARAM_NAMES` covers the weights, gate parameters and candidate gains;
  * a closed loop CITS -> `SigmoidGate` plant -> CITS feedback composes, the CITS and the plant are in the cone, and the fast single-shooting objective matches the object-graph objective in value (`1e-6`) and gradient (`1e-5`) at `x0` and at a perturbed theta with `candidate_0_0.kp` / `Ti` as theta.
* `tests/estimator/test_fast_shooting_later_producer.py`: PID -> stateless plant -> PID loop composes whatever edge the cycle cut removes; when the plant is the later producer it is threaded as the single feedback lag variable; value + gradient parity.
* Existing `test_fast_shooting.py`, `test_two_zone_wall.py`, `test_batched_shooting.py`, `tests/systems/controller`, `tests/simulator`: 102 passed (WSL, torch 2.11+cu128, full Graphviz toolset).

## Effect on the HTR case
`Simulator.compose` on the Stage 2 model, before / after:

```
before: RuntimeError: captured input ('R08_01', 'supplyAirFlowRate') depends on theta component 'R08_07'
after:  COMPOSE OK  cone = 4 zones + 4 radiators + 12 CITS + AHU, captured = 54, feedback = 16
```

The batched CUDA-graph shooting run (`method=("custom", "batched-sqp", "ad")`, `model.to("cuda")`) on this model is in progress; timing will be added as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
