### PR TITLE
Translator: Brick 1.4 / BMS graph patterns, pattern-walker and MILP fixes (#148, #145, #155, #157, #169)

### DIFF
--- a/twin4build/core/__init__.py
+++ b/twin4build/core/__init__.py
@@ -129,6 +129,7 @@ class ontology:
     RDFS = os.path.join(_ONTOLOGY_DIR, "rdfs.ttl")
     OWL = os.path.join(_ONTOLOGY_DIR, "owl.ttl")
     REC = os.path.join(_ONTOLOGY_DIR, "rec.ttl")
+    BRICKREF = os.path.join(_ONTOLOGY_DIR, "brickref.ttl")
 
     @classmethod
     def local_source(cls, namespace_uri) -> "str | None":
@@ -147,6 +148,12 @@ class ontology_remote:
     BRICK = "https://brickschema.org/schema/1.4.1/Brick.ttl"
     T4B = "http://twin4build.org/"
     BOT = "http://www.w3id.org/bot/bot.ttl"
+    # The Brick "ref" schema is not served under its namespace URI
+    # (https://brickschema.org/schema/Brick/ref# is a 404); the source of
+    # truth is the Brick repository.
+    BRICKREF = (
+        "https://raw.githubusercontent.com/BrickSchema/Brick/master/support/ref-schema.ttl"
+    )
 
     @classmethod
     def remote_source(cls, namespace_uri) -> "str | None":
@@ -165,6 +172,7 @@ _LOCAL_BY_NAMESPACE = {
     str(namespace.RDFS): ontology.RDFS,
     str(namespace.OWL): ontology.OWL,
     str(namespace.REC): ontology.REC,
+    str(namespace.BRICKREF): ontology.BRICKREF,
 }
 
 _REMOTE_BY_NAMESPACE = {
@@ -175,4 +183,5 @@ _REMOTE_BY_NAMESPACE = {
     str(namespace.BRICK): ontology_remote.BRICK,
     str(namespace.T4B): ontology_remote.T4B,
     str(namespace.BOT): ontology_remote.BOT,
+    str(namespace.BRICKREF): ontology_remote.BRICKREF,
 }

--- a/twin4build/core/ontologies/README.md
+++ b/twin4build/core/ontologies/README.md
@@ -25,3 +25,4 @@ against the same pinned versions, or bump the versions deliberately in
 | `rdfs.ttl` | http://www.w3.org/2000/01/rdf-schema# | - | W3C |
 | `owl.ttl` | http://www.w3.org/2002/07/owl# | - | W3C |
 | `rec.ttl` | https://w3id.org/rec# | latest | MIT |
+| `brickref.ttl` | https://raw.githubusercontent.com/BrickSchema/Brick/master/support/ref-schema.ttl (namespace `https://brickschema.org/schema/Brick/ref#`, not served at that URI) | master, fetched 2026-09-09 | BSD-3-Clause |

--- a/twin4build/core/ontologies/brickref.ttl
+++ b/twin4build/core/ontologies/brickref.ttl
@@ -1,0 +1,264 @@
+@prefix bacnet: <http://data.ashrae.org/bacnet/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
+@prefix s223: <http://data.ashrae.org/standard223#> .
+@prefix sdo: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ref:BACnetReferenceShape a sh:NodeShape ;
+    skos:definition "Infers a BACnetReference instance from the object of an hasExternalReference." ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition ref:BACnetReference ;
+            sh:object ref:BACnetReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
+
+ref:ExternalReferenceShape a sh:NodeShape ;
+    sh:property [ sh:message "All ExternalReference must have an rdfs:label" ;
+            sh:minCount 1 ;
+            sh:path rdfs:label ],
+        [ sh:message "All ExternalReference must have an skos:definition" ;
+            sh:minCount 1 ;
+            sh:path skos:definition ] ;
+    sh:target [ a sh:SPARQLTarget ;
+            sh:prefixes <https://brickschema.org/schema/Brick/ref> ;
+            sh:select """
+    SELECT ?this WHERE {
+     ?this rdfs:subClassOf+ ref:ExternalReference .
+    }
+    """ ] .
+
+ref:IFCReferenceShape a sh:NodeShape ;
+    skos:definition "Infers a IFCReference instance from the object of an hasExternalReference." ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition ref:IFCReference ;
+            sh:object ref:IFCReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
+
+ref:PreferredShape a sh:NodeShape ;
+    sh:property [ sh:message "An entity can only have one 'preferred' External Reference" ;
+            sh:path ref:hasExternalReference ;
+            sh:qualifiedMaxCount 1 ;
+            sh:qualifiedValueShape [ sh:class ref:ExternalReference ;
+                    sh:property [ sh:datatype xsd:boolean ;
+                            sh:hasValue true ;
+                            sh:path ref:preferred ] ] ] ;
+    sh:targetSubjectsOf ref:hasExternalReference .
+
+ref:TimeseriesReferenceShape a sh:NodeShape ;
+    skos:definition "Infers a TimeseriesReference instance from the object of an hasExternalReference." ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition ref:TimeseriesReference ;
+            sh:object ref:TimeseriesReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
+
+ref:bacnet-read-property a owl:DatatypeProperty ;
+    rdfs:label "bacnet-read-property" ;
+    rdfs:comment "The property of the BACnet object to read to get the current value of this entity." .
+
+ref:hasTimeseriesReference a owl:ObjectProperty ;
+    rdfs:label "hasTimeseriesReference" ;
+    rdfs:range ref:TimeseriesReference ;
+    rdfs:subPropertyOf ref:hasExternalReference ;
+    skos:definition "Metadata for accessing related timeseries data: Relates a data source (such as a Brick Point or 223 Property) to the TimeseriesReference that indicates where and how the data for this point is stored"@en .
+
+bacnet:contains a owl:ObjectProperty ;
+    rdfs:label "contains" ;
+    rdfs:comment "The BACnet device that hosts this BACnet object." ;
+    rdfs:range bacnet:device .
+
+bacnet:description a bacnet:StandardProperty,
+        owl:DatatypeProperty ;
+    bacnet:propertyEnum bacnet:PropertyIdentifier-description ;
+    bacnet:propertyName "description" ;
+    bacnet:propertyRef bacnet:Description ;
+    skos:definition "The content of the description field of the BACnet object." .
+
+bacnet:object-identifier a bacnet:StandardProperty,
+        rdf:Property,
+        owl:DatatypeProperty ;
+    rdfs:label "object-identifier" ;
+    bacnet:propertyEnum bacnet:PropertyIdentifier-object-identifier ;
+    bacnet:propertyName "object-identifier" ;
+    bacnet:propertyOf bacnet:Object ;
+    bacnet:propertyRef bacnet:Object_Identifier ;
+    rdfs:subPropertyOf bacnet:ReadableProperty ;
+    skos:definition "The BACnet object identifier" .
+
+bacnet:object-name a bacnet:StandardProperty,
+        owl:DatatypeProperty ;
+    bacnet:propertyEnum bacnet:PropertyIdentifier-object-name ;
+    bacnet:propertyName "object-name" ;
+    bacnet:propertyOf bacnet:Object ;
+    bacnet:propertyRef bacnet:Object_Name ;
+    rdfs:subPropertyOf bacnet:ReadableProperty ;
+    skos:definition "The content of the name field of the BACnet object." .
+
+bacnet:object-type a bacnet:StandardProperty,
+        rdf:Property,
+        owl:DatatypeProperty ;
+    rdfs:label "object-type" ;
+    bacnet:propertyEnum bacnet:PropertyIdentifier-object-type ;
+    bacnet:propertyName "object-type" ;
+    bacnet:propertyOf bacnet:Object ;
+    bacnet:propertyRef bacnet:Object_Type ;
+    rdfs:subPropertyOf bacnet:ReadableProperty ;
+    skos:definition "The type of the BACnet object" .
+
+<https://brickschema.org/schema/Brick/ref> a owl:Ontology ;
+    dcterms:creator ( [ a sdo:Person ;
+                sdo:email "gtfierro@mines.edu" ;
+                sdo:name "Gabe Fierro" ] ) ;
+    dcterms:title "Ref Schema" ;
+    sh:declare [ sh:namespace "http://www.w3.org/2000/01/rdf-schema#"^^xsd:anyURI ;
+            sh:prefix "rdfs" ],
+        [ sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
+            sh:prefix "rdf" ],
+        [ sh:namespace "https://brickschema.org/schema/Brick/ref#"^^xsd:anyURI ;
+            sh:prefix "ref" ],
+        [ sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
+            sh:prefix "sh" ],
+        [ sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
+            sh:prefix "rdf" ],
+        [ sh:namespace "http://www.w3.org/2002/07/owl#"^^xsd:anyURI ;
+            sh:prefix "owl" ] .
+
+ref:BACnetURI a owl:DatatypeProperty ;
+    rdfs:label "BACnetURI" ;
+    rdfs:comment "Clause Q.8 BACnet URI scheme: bacnet:// <device> / <object> [ / <property> [ / <index> ]]" .
+
+ref:hasIfcProjectReference a owl:ObjectProperty ;
+    rdfs:label "hasIfcProjectReference" ;
+    skos:definition "A reference to the IFC Project that defines this entity" .
+
+ref:hasTimeseriesId a owl:DatatypeProperty ;
+    rdfs:label "hasTimeseriesId" ;
+    skos:definition "The unique identifier (primary key) for this TimeseriesReference in some database"@en .
+
+ref:ifcFileLocation a owl:DatatypeProperty ;
+    rdfs:label "The location of the IFC file defining a project" ;
+    rdfs:range xsd:string .
+
+ref:ifcGlobalID a owl:DatatypeProperty ;
+    rdfs:label "ifcGlobalID" ;
+    skos:definition "The IFC Global ID of the entity" .
+
+ref:ifcName a owl:DatatypeProperty ;
+    rdfs:label "ifcName" ;
+    skos:definition "The name of the IFC entity" .
+
+ref:ifcProject a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "IfcProject" ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:ifcFileLocation ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:ifcProjectID ] .
+
+ref:ifcProjectID a owl:DatatypeProperty ;
+    rdfs:label "ifcProjectID" ;
+    skos:definition "The IFC ID of the containing project" .
+
+ref:preferred a owl:DatatypeProperty ;
+    skos:definition "An entity can have one 'preferred' External Reference. Consumers of the model should prioritize any external reference with the 'preferred' property" .
+
+ref:storedAt a owl:DatatypeProperty ;
+    rdfs:label "storedAt" ;
+    skos:definition "A reference to where the data for this TimeseriesReference is stored"@en .
+
+ref:BACnetReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "BACnet Reference" ;
+    rdfs:subClassOf ref:ExternalReference ;
+    skos:definition "A reference to the BACnet object represented by this entity." ;
+    sh:or ( [ sh:property [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:path bacnet:object-type ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:path bacnet:description ],
+                    [ a sh:PropertyShape ;
+                        sh:class bacnet:EngineeringUnitsEnumerationValue ;
+                        sh:maxCount 1 ;
+                        sh:minCount 0 ;
+                        sh:path bacnet:units ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:minLength 1 ;
+                        sh:path bacnet:object-name ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:minCount 1 ;
+                        sh:path bacnet:object-identifier ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype bacnet:Property ;
+                        sh:defaultValue bacnet:Present_Value ;
+                        sh:path ref:read-property ] ] [ sh:property [ a sh:PropertyShape ;
+                        skos:definition "Clause Q.8 BACnet URI scheme: bacnet:// <device> / <object> [ / <property> [ / <index> ]]" ;
+                        sh:datatype xsd:string ;
+                        sh:path ref:BACnetURI ] ] ) ;
+    sh:property [ a sh:PropertyShape ;
+            sh:class bacnet:device ;
+            sh:minCount 1 ;
+            sh:path bacnet:contains ] .
+
+ref:IFCReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "Industry Foundation Classes Reference" ;
+    rdfs:subClassOf ref:ExternalReference ;
+    skos:definition "A reference to an entity in an IFC project which may contain additional metadata about this entity." ;
+    sh:property [ a sh:PropertyShape ;
+            skos:definition "Name of the entity in IFC" ;
+            sh:datatype xsd:string ;
+            sh:path ref:ifcName ],
+        [ a sh:PropertyShape ;
+            skos:definition "The global ID of the entity in the IFC project" ;
+            sh:datatype xsd:string ;
+            sh:minCount 1 ;
+            sh:path ref:ifcGlobalID ],
+        [ a sh:PropertyShape ;
+            skos:definition "Reference to an IFC Project object, containing the project ID" ;
+            sh:class ref:ifcProject ;
+            sh:minCount 1 ;
+            sh:path ref:hasIfcProjectReference ] .
+
+ref:TimeseriesReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "Timeseries Reference" ;
+    rdfs:subClassOf ref:ExternalReference ;
+    skos:definition "A reference to a stream of timeseries data in a database. Contains the data for this entity" ;
+    sh:property [ a sh:PropertyShape ;
+            skos:definition "The identifier for the timeseries data corresponding to this point" ;
+            sh:datatype xsd:string ;
+            sh:minCount 1 ;
+            sh:path ref:hasTimeseriesId ],
+        [ a sh:PropertyShape ;
+            skos:definition "Refers to a database storing the timeseries data for the related point. Properties on this class are *to be determined*; feel free to add arbitrary properties onto Database instances for your particular deployment" ;
+            sh:nodeKind sh:IRIOrLiteral ;
+            sh:path ref:storedAt ] .
+
+ref:ExternalReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "External reference" ;
+    rdfs:subClassOf s223:ExternalReference ;
+    skos:definition "The parent class of all external reference types" .
+
+ref:hasExternalReference a owl:ObjectProperty ;
+    rdfs:label "hasExternalReference" ;
+    rdfs:subPropertyOf s223:hasExternalReference ;
+    skos:definition "Points to the external reference for this entity, which contains additional metadata/data not included in this graph." .
+

--- a/twin4build/core/ontologies/refresh.py
+++ b/twin4build/core/ontologies/refresh.py
@@ -27,6 +27,7 @@ SOURCES = {
     "rdfs.ttl": "http://www.w3.org/2000/01/rdf-schema#",
     "owl.ttl": "http://www.w3.org/2002/07/owl#",
     "rec.ttl": "https://w3id.org/rec#",
+    "brickref.ttl": ontology_remote.BRICKREF,
 }
 
 

--- a/twin4build/model/model.py
+++ b/twin4build/model/model.py
@@ -723,20 +723,12 @@ class Model:
                 return False
             return any(str(sc.uri) == str(b.uri) for sc in a.super_classes)
 
-        for component in self._simulation_model.components.values():
-            setter = getattr(component, "set_transformation", None)
-            if not callable(setter):
-                continue
-            semantic_nodes = sim2sem.get(component)
-            if not semantic_nodes:
-                continue
-
-            # Gather every rule that matches at least one of the
-            # component's semantic counterparts.
+        def _winner(nodes, component_id):
+            """Most-specific rule matching any of ``nodes`` (first-declared on ties)."""
             matched: List[Tuple[Any, Callable[[Any], Any], Any]] = []
             for stype, fn, original_key in rules:
                 hit = False
-                for node in semantic_nodes:
+                for node in nodes:
                     isinstance_check = getattr(node, "isinstance", None)
                     if callable(isinstance_check) and isinstance_check(
                         stype.uri
@@ -745,11 +737,8 @@ class Model:
                         break
                 if hit:
                     matched.append((stype, fn, original_key))
-
             if not matched:
-                continue
-
-            # Most-specific wins; first-declared on ties.
+                return None
             winner = matched[0]
             for cand in matched[1:]:
                 if _is_strict_subclass(cand[0], winner[0]):
@@ -760,11 +749,35 @@ class Model:
                     warnings.warn(
                         f"set_transformations: rules for {cand[2]!r} and "
                         f"{winner[2]!r} both match component "
-                        f"{component.id!r} with no subclass relationship; "
+                        f"{component_id!r} with no subclass relationship; "
                         f"keeping the first-declared rule ({winner[2]!r}).",
                         stacklevel=2,
                     )
-            setter(winner[1])
+            return winner
+
+        for component in self._simulation_model.components.values():
+            semantic_nodes = sim2sem.get(component)
+            if not semantic_nodes:
+                continue
+            typed_setter = getattr(component, "set_transformation_by_type", None)
+            if callable(typed_setter):
+                # Components that model several semantic nodes with
+                # different roles (an OutdoorEnvironmentSystem models an
+                # outdoor temperature sensor AND a solar irradiance sensor)
+                # get one rule per node, keyed by the class that won for
+                # that node, so a Temperature_Sensor rule and a
+                # Solar_Irradiance_Sensor rule reach their own feeds.
+                for node in semantic_nodes:
+                    winner = _winner([node], component.id)
+                    if winner is not None:
+                        typed_setter(winner[0], winner[1])
+                continue
+            setter = getattr(component, "set_transformation", None)
+            if not callable(setter):
+                continue
+            winner = _winner(semantic_nodes, component.id)
+            if winner is not None:
+                setter(winner[1])
 
         return self
 

--- a/twin4build/systems/air_handling_unit/air_handling_unit_system.py
+++ b/twin4build/systems/air_handling_unit/air_handling_unit_system.py
@@ -589,6 +589,11 @@ def brick_signature_pattern():
             core.namespace.BRICK.Enclosed_space,
             core.namespace.BRICK.Open_space,
             core.namespace.BRICK.HVAC_Zone,
+            # Brick 1.4 deprecates its location classes in favour of
+            # RealEstateCore (``brick:Room brick:isReplacedBy rec:Room``,
+            # ``brick:HVAC_Zone`` -> ``rec:HVACZone`` < ``rec:Zone``).
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
         )
     )
 
@@ -721,6 +726,11 @@ def brick_signature_pattern_vav_dampers():
             core.namespace.BRICK.Enclosed_space,
             core.namespace.BRICK.Open_space,
             core.namespace.BRICK.HVAC_Zone,
+            # Brick 1.4 deprecates its location classes in favour of
+            # RealEstateCore (``brick:Room brick:isReplacedBy rec:Room``,
+            # ``brick:HVAC_Zone`` -> ``rec:HVACZone`` < ``rec:Zone``).
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
         )
     )
     vavs = Node(cls=core.namespace.BRICK.VAV)
@@ -892,7 +902,102 @@ def brick_signature_pattern_vav_dampers():
 # ``add_modeled_node(ahu)`` and is mutually exclusive with the VAV
 # variant via the matcher's existing exclusion machinery (rather than
 # relying on the broken mixed-mutex semantics today).
+def brick_signature_pattern_vav_damper_commands():
+    """AHU pattern for VAV systems whose damper command is a direct VAV point.
+
+    Sibling of :func:`brick_signature_pattern_vav_dampers` for BMS-derived
+    BRICK graphs that do not model a ``brick:Damper`` equipment under each
+    VAV but attach the damper command point to the VAV itself (e.g. the
+    Hoeje-Taastrup Raadhus graph, where every VAV carries a
+    ``Damper_Position_Command`` next to its flow sensor / setpoint)::
+
+        AHU  feeds     VAV
+        VAV  feeds     Room / Zone
+        VAV  hasPoint  Damper_Position_Command | Damper_Position_Setpoint
+
+    Everything else (connections, Vector indexing by ``spaces``, the
+    free-floating optional outside-air sensor and the optional supply-air
+    temperature setpoint) mirrors the damper-equipment variant, so the
+    downstream BuildingSpace / sensor patterns line up on the same
+    ``spaces`` slots.
+
+    The two AHU patterns are mutually exclusive in practice: a VAV either
+    has a ``Damper`` part (damper-equipment variant) or a direct damper
+    command point (this variant).  A graph that models *both* on the same
+    VAV would produce two AirHandlingUnitSystem components per AHU (see the
+    note below on the non-exclusive multi-member ``ModeledNode`` mutex).
+    """
+    sp = SignaturePattern(
+        id="air_handling_unit_signature_pattern_brick_vav_damper_commands"
+    )
+
+    ahu = Node(cls=core.namespace.BRICK.AHU)
+    spaces = Node(
+        cls=(
+            core.namespace.BRICK.Room,
+            core.namespace.BRICK.Enclosed_space,
+            core.namespace.BRICK.Open_space,
+            core.namespace.BRICK.HVAC_Zone,
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
+        )
+    )
+    vavs = Node(cls=core.namespace.BRICK.VAV)
+    damper_cmds = Node(
+        cls=(
+            core.namespace.BRICK.Damper_Position_Command,
+            core.namespace.BRICK.Damper_Position_Setpoint,
+        )
+    )
+    sat_setpoint = Node(cls=core.namespace.BRICK.Supply_Air_Temperature_Setpoint)
+    oat_sensor = Node(cls=core.namespace.BRICK.Outside_Air_Temperature_Sensor)
+
+    feeds = Predicate((core.namespace.BRICK.feeds, core.namespace.FSO.feedsFluidTo))
+
+    sp.add_rule(SetAnyPathRule(subject=ahu, object=vavs, predicate=feeds))
+    sp.add_rule(StepRule(subject=vavs, object=spaces, predicate=feeds))
+    sp.add_rule(
+        StepRule(
+            subject=vavs, object=damper_cmds, predicate=core.namespace.BRICK.hasPoint
+        )
+    )
+    sp.add_node(oat_sensor, optional=True)
+    sp.add_rule(
+        OptionalRule(
+            subject=ahu,
+            object=sat_setpoint,
+            predicate=core.namespace.BRICK.hasPoint,
+        )
+    )
+
+    sp.add_connection(
+        spaces, "indoorTemperature", "exhaustTemperature", input_port_index=spaces
+    )
+    sp.add_connection(
+        damper_cmds,
+        "inputSignal",
+        "supplyDamperPosition",
+        output_port_index=damper_cmds,
+        input_port_index=spaces,
+    )
+    sp.add_connection(
+        damper_cmds,
+        "inputSignal",
+        "exhaustDamperPosition",
+        output_port_index=damper_cmds,
+        input_port_index=spaces,
+    )
+    sp.add_connection(sat_setpoint, "measuredValue", "supplyAirTemperatureSetpoint")
+    sp.add_connection(oat_sensor, "outdoorTemperature", "outdoorAirTemperature")
+
+    ModeledNode([ahu, vavs, damper_cmds])
+    return sp
+
+
 AirHandlingUnitSystem.add_signature_pattern(brick_signature_pattern_vav_dampers())
+AirHandlingUnitSystem.add_signature_pattern(
+    brick_signature_pattern_vav_damper_commands()
+)
 
 # Deprecated aliases (removed in twin4build 2.1)
 AirHandlingUnitTorchSystem = AirHandlingUnitSystem

--- a/twin4build/systems/building_space/building_space_system.py
+++ b/twin4build/systems/building_space/building_space_system.py
@@ -544,6 +544,12 @@ def _brick_space_pattern(topology: str, with_volume: bool):
     outside_air_temperature_sensor = Node(
         cls=core.namespace.BRICK.Outside_Air_Temperature_Sensor
     )
+    # Room-level radiator: BMS graphs carry only a valve command on the room
+    # (no radiator equipment).  When a :class:`SpaceHeaterSystem` is matched
+    # there (see its ``brick_signature_pattern_room_heating_command``), its
+    # delivered ``Power`` is the room's ``heatGain``.  Optional, so rooms
+    # without heating still match.
+    heating_cmd = Node(cls=core.namespace.BRICK.Heating_Command)
     feeds = Predicate((core.namespace.BRICK.feeds, core.namespace.FSO.feedsFluidTo))
 
     suffix = "_with_volume" if with_volume else ""
@@ -593,6 +599,12 @@ def _brick_space_pattern(topology: str, with_volume: bool):
     sp.add_connection(
         outside_air_temperature_sensor, "outdoorTemperature", "outdoorTemperature"
     )
+    sp.add_rule(
+        OptionalRule(
+            subject=space, object=heating_cmd, predicate=core.namespace.BRICK.hasPoint
+        )
+    )
+    sp.add_connection(heating_cmd, "Power", "heatGain")
     if with_volume:
         _add_brick_volume_parameter(sp, space)
     # Interzonal/boundary coupling is modeled by a separate WallSystem

--- a/twin4build/systems/building_space/building_space_system.py
+++ b/twin4build/systems/building_space/building_space_system.py
@@ -460,49 +460,128 @@ def saref_signature_pattern():
     return sp
 
 
-def brick_signature_pattern():  # Fits to site A
-    """
-    Get the BRICK-only signature pattern of the building space component.
+_BRICK_SPACE_CLASSES = (
+    core.namespace.BRICK.Room,
+    core.namespace.BRICK.Enclosed_space,
+    core.namespace.BRICK.Open_space,
+    core.namespace.BRICK.HVAC_Zone,
+    # Brick 1.4 deprecates its location classes in favour of
+    # RealEstateCore (``brick:Room brick:isReplacedBy rec:Room``,
+    # ``brick:HVAC_Zone`` -> ``rec:HVACZone`` < ``rec:Zone``).
+    core.namespace.REC.Room,
+    core.namespace.REC.Zone,
+    core.namespace.BOT.Space,
+)
 
-    Returns:
-        SignaturePattern: The BRICK-only signature pattern of the building space component.
-    """
+_SOLAR_SENSOR_CLASSES = (
+    # ``Global_Solar_Irradiation_Sensor`` is not a Brick class (it survives
+    # for graphs that extend Brick with it); ``Solar_Irradiance_Sensor`` is
+    # the Brick 1.4 class (W/m2).
+    core.namespace.BRICK.Global_Solar_Irradiation_Sensor,
+    core.namespace.BRICK.Solar_Irradiance_Sensor,
+)
 
-    ahu = Node(cls=core.namespace.BRICK.AHU)
-    # node1 = Node(cls=core.namespace.BRICK.Damper)
-    # node2 = Node(cls=core.namespace.BRICK.Zone)  # Compatibility with both site A and B (A uses Zone and B uses HVAC_Zone)
-    space = Node(
+_REHEAT_PART_CLASSES = (
+    core.namespace.BRICK.Heating_Coil,
+    core.namespace.BRICK.Cooling_Coil,
+    core.namespace.BRICK.Reheat_Valve,
+)
+_REHEAT_POINT_CLASSES = (
+    core.namespace.BRICK.Reheat_Command,
+    core.namespace.BRICK.Heating_Command,
+    core.namespace.BRICK.Valve_Command,
+)
+
+
+def _add_brick_volume_parameter(sp, space):
+    """Bind the room volume ``space brick:volume [ brick:value x ]`` to ``mass.V``.
+
+    The chain is *required* and the value holder is a modeled node: with an
+    ``OptionalRule`` chain the translator's disconnected-merge step treats
+    the free literal as a shared resource and copies one room's volume into
+    every other room (the same failure mode documented for the sensor
+    ``externalref`` chains).  Every Brick space pattern is therefore
+    registered twice -- with and without this chain -- and the MILP prefers
+    the with-volume variant (one more modeled node) whenever the graph
+    carries the geometry.
+    """
+    volume_node = Node(cls=(core.BlankNode,))
+    volume_value = Node(
         cls=(
-            core.namespace.BRICK.Room,
-            core.namespace.BRICK.Enclosed_space,
-            core.namespace.BRICK.Open_space,
-            core.namespace.BRICK.HVAC_Zone,
-            core.namespace.BOT.Space,
+            core.namespace.XSD.float,
+            core.namespace.XSD.double,
+            core.namespace.XSD.decimal,
+            core.namespace.XSD.integer,
         )
-    )  # TODO: '_space' should be '_Office', but the site b ttl file has a bug
-    solar_radiance_sensor = Node(cls=core.namespace.BRICK.Global_Solar_Irradiation_Sensor)
+    )
+    sp.add_rule(StepRule(subject=space, object=volume_node, predicate=core.namespace.BRICK.volume))
+    sp.add_rule(StepRule(subject=volume_node, object=volume_value, predicate=core.namespace.BRICK.value))
+    sp.add_parameter("mass.V", volume_value)
+    sp.add_modeled_node(volume_node)
+
+
+def _brick_space_pattern(topology: str, with_volume: bool):
+    """Factory for the Brick building-space patterns.
+
+    ``topology``:
+
+    * ``"vav_no_reheat"`` -- ``AHU feeds VAV feeds Room`` where the VAV is a
+      plain damper box (no coil part, no reheat / heating / valve command
+      point): the room receives ``AHU.supplyAirTemperature``.
+    * ``"vav"`` -- ``AHU feeds VAV feeds Room`` with reheat: the room receives
+      ``VAV.outletAirTemperature`` from a :class:`FanCoilUnitSystem`.
+    * ``"direct"`` -- AHU feeds the room through any path *not* via a VAV
+      (Mortar site A style): the room receives ``AHU.supplyAirTemperature``.
+
+    All variants share the ``space`` modeled node, so the MILP keeps one per
+    room; ``with_volume`` adds the ``brick:volume`` parameter chain (see
+    :func:`_add_brick_volume_parameter`).
+    """
+    ahu = Node(cls=core.namespace.BRICK.AHU)
+    vav = Node(cls=core.namespace.BRICK.VAV)
+    space = Node(cls=_BRICK_SPACE_CLASSES)
+    solar_radiance_sensor = Node(cls=_SOLAR_SENSOR_CLASSES)
     outside_air_temperature_sensor = Node(
         cls=core.namespace.BRICK.Outside_Air_Temperature_Sensor
     )
-
-    vav = Node(cls=core.namespace.BRICK.VAV)
-
     feeds = Predicate((core.namespace.BRICK.feeds, core.namespace.FSO.feedsFluidTo))
 
+    suffix = "_with_volume" if with_volume else ""
     sp = SignaturePattern(
-        id="building_space_signature_pattern_brick",
+        id=f"building_space_signature_pattern_brick_{topology}{suffix}"
     )
+    sp.add_node(solar_radiance_sensor, optional=True)  # not always present
+    sp.add_node(outside_air_temperature_sensor, optional=True)  # not always present
 
-    sp.add_node(solar_radiance_sensor, optional=True) # Optional because it is not always present
-    sp.add_node(outside_air_temperature_sensor, optional=True) # Optional because it is not always present
-
-    sp.add_rule(
-        AnyPathRule(
-            subject=ahu, object=space, predicate=feeds, endpoints_only=True
-        ) & NoStepRule(subject=ahu, object=vav, predicate=feeds)
-    )
-
-
+    if topology == "direct":
+        sp.add_rule(
+            AnyPathRule(subject=ahu, object=space, predicate=feeds, endpoints_only=True)
+            & NoStepRule(subject=ahu, object=vav, predicate=feeds)
+        )
+        sp.add_connection(ahu, "supplyAirTemperature", "supplyAirTemperature")
+    else:
+        sp.add_rule(StepRule(subject=ahu, object=vav, predicate=feeds))
+        sp.add_rule(StepRule(subject=vav, object=space, predicate=feeds))
+        if topology == "vav_no_reheat":
+            sp.add_rule(
+                NoStepRule(
+                    subject=vav,
+                    object=Node(cls=_REHEAT_PART_CLASSES),
+                    predicate=core.namespace.BRICK.hasPart,
+                )
+            )
+            sp.add_rule(
+                NoStepRule(
+                    subject=vav,
+                    object=Node(cls=_REHEAT_POINT_CLASSES),
+                    predicate=core.namespace.BRICK.hasPoint,
+                )
+            )
+            sp.add_connection(ahu, "supplyAirTemperature", "supplyAirTemperature")
+        elif topology == "vav":
+            sp.add_connection(vav, "outletAirTemperature", "supplyAirTemperature")
+        else:
+            raise ValueError(topology)
 
     sp.add_connection(
         ahu, "supplyAirFlowRate", "supplyAirFlowRate", output_port_index=space
@@ -510,105 +589,37 @@ def brick_signature_pattern():  # Fits to site A
     sp.add_connection(
         ahu, "exhaustAirFlowRate", "exhaustAirFlowRate", output_port_index=space
     )
-    # # sp.add_input("numberOfPeople", node5, "measuredValue")
+    sp.add_connection(solar_radiance_sensor, "globalIrradiation", "globalIrradiation")
     sp.add_connection(
         outside_air_temperature_sensor, "outdoorTemperature", "outdoorTemperature"
     )
-    sp.add_connection(
-        solar_radiance_sensor, "globalIrradiation", "globalIrradiation"
-    )
-    sp.add_connection(ahu, "supplyAirTemperature", "supplyAirTemperature")
-
+    if with_volume:
+        _add_brick_volume_parameter(sp, space)
     # Interzonal/boundary coupling is modeled by a separate WallSystem
     # (wired manually, or via a future wall/adjacency signature pattern).
     sp.add_modeled_node(space)
-
-    # sp_eq = SignaturePattern(
-    #     id="building_space_signature_pattern_brick_eq",
-    # )
-
-    #######################
-
-    # sp_eq.add_rule(
-    #     StepRule(subject=node0, object=node2, predicate=core.namespace.BRICK.feeds)
-    # )
-    # sp_eq.add_rule(
-    #     StepRule(subject=node2, object=node3, predicate=core.namespace.BRICK.hasPart)
-    # )
-
-    # # TODO: How to handle inverse predicates?
-    # diff = core.Diff()
-    # diff.remove(node0, core.namespace.BRICK.feeds, node2)
-    # diff.remove(node2, core.namespace.BRICK.isFedBy, node0)
-    # diff.add(node2, core.namespace.BRICK.hasPart, node3)
-
-    # sp.add_equivalent(sp_eq, diff)
-
     return sp
 
 
-def brick_signature_pattern_vav():
-    """
-    BRICK signature pattern for a building space served by an AHU via a VAV/FCU.
-
-    Mirrors physical reality: AHU → VAV/FCU (adds reheat) → Room.
-    The supply air temperature entering the room comes from the FCU outlet,
-    not directly from the AHU.
-
-    Topology::
-
-        AHU  feeds  VAV  feeds  Room
-
-    Connections:
-        AHU.supplyAirFlowRate  → BuildingSpace.supplyAirFlowRate
-        AHU.exhaustAirFlowRate → BuildingSpace.exhaustAirFlowRate
-        VAV.outletAirTemperature → BuildingSpace.supplyAirTemperature
-
-    The MILP solver will prefer this pattern over the direct AHU pattern when
-    a VAV is present between the AHU and the room, because it covers more nodes.
-    """
-    ahu = Node(cls=core.namespace.BRICK.AHU)
-    vav = Node(cls=core.namespace.BRICK.VAV)
-    space = Node(
-        cls=(
-            core.namespace.BRICK.Room,
-            core.namespace.BRICK.Enclosed_space,
-            core.namespace.BRICK.Open_space,
-            core.namespace.BRICK.HVAC_Zone,
-            core.namespace.BOT.Space,
-        )
-    )
-    solar_radiance_sensor = Node(cls=core.namespace.BRICK.Global_Solar_Irradiation_Sensor )
-    outside_air_temperature_sensor = Node(
-        cls=core.namespace.BRICK.Outside_Air_Temperature_Sensor
-    )
-
-    feeds = Predicate((core.namespace.BRICK.feeds, core.namespace.FSO.feedsFluidTo))
-
-    sp = SignaturePattern(id="building_space_signature_pattern_brick_vav")
-
-    sp.add_node(solar_radiance_sensor, optional=True) # Optional because it is not always present
-    sp.add_node(outside_air_temperature_sensor, optional=True) # Optional because it is not always present
-
-    sp.add_rule(StepRule(subject=ahu, object=vav, predicate=feeds))
-    sp.add_rule(StepRule(subject=vav, object=space, predicate=feeds))
-
-    sp.add_connection(
-        ahu, "supplyAirFlowRate", "supplyAirFlowRate", output_port_index=space
-    )
-    sp.add_connection(
-        ahu, "exhaustAirFlowRate", "exhaustAirFlowRate", output_port_index=space
-    )
-    sp.add_connection(vav, "outletAirTemperature", "supplyAirTemperature")
-    sp.add_connection(solar_radiance_sensor, "globalIrradiation", "globalIrradiation")
-    sp.add_connection(outside_air_temperature_sensor, "outdoorTemperature", "outdoorTemperature")
-    sp.add_modeled_node(space)
-
-    return sp
+def brick_signature_pattern_vav_no_reheat(with_volume: bool = False):
+    """See :func:`_brick_space_pattern` (``"vav_no_reheat"``)."""
+    return _brick_space_pattern("vav_no_reheat", with_volume)
 
 
-BuildingSpaceSystem.add_signature_pattern(brick_signature_pattern_vav())
-BuildingSpaceSystem.add_signature_pattern(brick_signature_pattern())
+def brick_signature_pattern_vav(with_volume: bool = False):
+    """See :func:`_brick_space_pattern` (``"vav"``); kept for site B / Mortar graphs."""
+    return _brick_space_pattern("vav", with_volume)
+
+
+def brick_signature_pattern(with_volume: bool = False):  # Fits to site A
+    """See :func:`_brick_space_pattern` (``"direct"``)."""
+    return _brick_space_pattern("direct", with_volume)
+
+
+for _with_volume in (True, False):
+    BuildingSpaceSystem.add_signature_pattern(brick_signature_pattern_vav_no_reheat(_with_volume))
+    BuildingSpaceSystem.add_signature_pattern(brick_signature_pattern_vav(_with_volume))
+    BuildingSpaceSystem.add_signature_pattern(brick_signature_pattern(_with_volume))
 BuildingSpaceSystem.add_signature_pattern(saref_signature_pattern())
 BuildingSpaceSystem.add_signature_pattern(saref_signature_pattern_sensor())
 

--- a/twin4build/systems/controller/controller_identification/controller_identification_pi_system.py
+++ b/twin4build/systems/controller/controller_identification/controller_identification_pi_system.py
@@ -38,6 +38,7 @@ from twin4build.translator.translator import (
     ModeledNode,
     Node,
     SetStepRule,
+    Predicate,
     SignaturePattern,
     StepRule,
 )
@@ -139,14 +140,7 @@ def brick_signature_pattern_vav():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(
-        cls=(
-            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
-            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
-            # the damper command tracks a supply-air-flow setpoint).
-            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
-        )
-    )
+    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
     actuators = Node(cls=core.namespace.BRICK.Command)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     timeseries_id = Node(cls=core.namespace.XSD.string)
@@ -174,6 +168,74 @@ def brick_signature_pattern_vav():
 ControllerIdentificationPISystem.add_signature_pattern(brick_signature_pattern_vav())
 
 
+def brick_signature_pattern_vav_room():
+    """BRICK VAV pattern with the loop variables on the *room* the VAV serves.
+
+    BMS-derived graphs (Hoeje-Taastrup Raadhus) keep the zone temperature
+    sensor and setpoints on the room and only the flow points and the
+    damper command on the VAV::
+
+        VAV  feeds     Room
+        Room hasPoint  Zone_Air_Temperature_Sensor              -> sensorValue
+        Room hasPoint  Zone_Air_Temperature_Setpoint (+ heating /
+                       cooling subclasses)                      -> setpointValue
+        VAV  hasPoint  Command (damper)                         -> actuator
+        VAV  hasPoint  Supply_Air_Flow_Setpoint                 -> onOffSignal
+
+    The loop identified is *damper = PI(zone temperature setpoint - zone
+    temperature)*, as in :func:`brick_signature_pattern_vav`.  The VAV's
+    supply-air-flow setpoint is the output of the room controller; it is
+    zero whenever the zone is off and positive otherwise, so it is offered
+    to the gate bus (``onOffSignal``) as the schedule-like signal, never as
+    a tracked setpoint (a pattern can feed one node into a port, so the
+    zone setpoints are not mirrored onto the gate bus here).
+    """
+    # The VAV is declared first on purpose: the matcher seeds each walk at
+    # the first node of the pattern graph (``ModeledNode`` members are not
+    # recognised as seeds), and seeding at the shared AHU would collapse
+    # the VAV branches of one room into a single match.
+    vav = Node(cls=core.namespace.BRICK.VAV)
+    room = Node(
+        cls=(
+            core.namespace.BRICK.Room,
+            core.namespace.BRICK.HVAC_Zone,
+            core.namespace.BRICK.Enclosed_space,
+            core.namespace.BRICK.Open_space,
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
+        )
+    )
+    sensors = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Sensor)
+    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
+    actuators = Node(cls=core.namespace.BRICK.Command)
+    flow_setpoints = Node(cls=core.namespace.BRICK.Supply_Air_Flow_Setpoint)
+    externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
+    timeseries_id = Node(cls=core.namespace.XSD.string)
+    feeds = Predicate((core.namespace.BRICK.feeds, core.namespace.FSO.feedsFluidTo))
+
+    sp = SignaturePattern(id="controller_identification_pi_vav_room_brick")
+    sp.add_rule(StepRule(subject=vav, object=room, predicate=feeds))
+    sp.add_rule(SetStepRule(subject=room, object=sensors, predicate=core.namespace.BRICK.hasPoint))
+    sp.add_rule(SetStepRule(subject=room, object=setpoints, predicate=core.namespace.BRICK.hasPoint))
+    sp.add_rule(SetStepRule(subject=vav, object=actuators, predicate=core.namespace.BRICK.hasPoint))
+    sp.add_rule(SetStepRule(subject=vav, object=flow_setpoints, predicate=core.namespace.BRICK.hasPoint))
+    sp.add_rule(StepRule(subject=actuators, object=externalref, predicate=core.namespace.BRICKREF.hasExternalReference))
+    sp.add_rule(StepRule(subject=externalref, object=timeseries_id, predicate=core.namespace.BRICKREF.hasTimeseriesId))
+
+    sp.add_connection(sensors, "measuredValue", "sensorValue", input_port_index=sensors)
+    sp.add_connection(setpoints, "measuredValue", "setpointValue", input_port_index=setpoints)
+    sp.add_connection(flow_setpoints, "measuredValue", "onOffSignal", input_port_index=flow_setpoints)
+    # Only the VAV and its command form the modeled identity: the room's
+    # sensor / setpoint points are shared by every VAV serving that room
+    # (four in some HTR rooms), and putting them in the group would make
+    # those VAV controllers mutually exclusive.
+    ModeledNode([vav, actuators])
+    return sp
+
+
+ControllerIdentificationPISystem.add_signature_pattern(brick_signature_pattern_vav_room())
+
+
 def brick_signature_pattern_vav_damper():
     """BRICK VAV pattern with damper-equipment-modeled actuator command.
 
@@ -189,14 +251,7 @@ def brick_signature_pattern_vav_damper():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(
-        cls=(
-            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
-            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
-            # the damper command tracks a supply-air-flow setpoint).
-            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
-        )
-    )
+    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
     damper_equip = Node(cls=core.namespace.BRICK.Damper)
     damper_cmd = Node(cls=core.namespace.BRICK.Damper_Position_Setpoint)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))

--- a/twin4build/systems/controller/controller_identification/controller_identification_pi_system.py
+++ b/twin4build/systems/controller/controller_identification/controller_identification_pi_system.py
@@ -139,7 +139,14 @@ def brick_signature_pattern_vav():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
+    setpoints = Node(
+        cls=(
+            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
+            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
+            # the damper command tracks a supply-air-flow setpoint).
+            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
+        )
+    )
     actuators = Node(cls=core.namespace.BRICK.Command)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     timeseries_id = Node(cls=core.namespace.XSD.string)
@@ -182,7 +189,14 @@ def brick_signature_pattern_vav_damper():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
+    setpoints = Node(
+        cls=(
+            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
+            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
+            # the damper command tracks a supply-air-flow setpoint).
+            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
+        )
+    )
     damper_equip = Node(cls=core.namespace.BRICK.Damper)
     damper_cmd = Node(cls=core.namespace.BRICK.Damper_Position_Setpoint)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))

--- a/twin4build/systems/controller/controller_identification/controller_identification_system.py
+++ b/twin4build/systems/controller/controller_identification/controller_identification_system.py
@@ -1463,7 +1463,14 @@ def brick_signature_pattern_vav():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
+    setpoints = Node(
+        cls=(
+            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
+            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
+            # the damper command tracks a supply-air-flow setpoint).
+            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
+        )
+    )
     actuators = Node(cls=core.namespace.BRICK.Command)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     timeseries_id = Node(cls=core.namespace.XSD.string)
@@ -1534,7 +1541,14 @@ def brick_signature_pattern_vav_damper():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
+    setpoints = Node(
+        cls=(
+            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
+            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
+            # the damper command tracks a supply-air-flow setpoint).
+            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
+        )
+    )
     damper_equip = Node(cls=core.namespace.BRICK.Damper)
     damper_cmd = Node(cls=core.namespace.BRICK.Damper_Position_Setpoint)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))

--- a/twin4build/systems/controller/controller_identification/controller_identification_system.py
+++ b/twin4build/systems/controller/controller_identification/controller_identification_system.py
@@ -1463,14 +1463,7 @@ def brick_signature_pattern_vav():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(
-        cls=(
-            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
-            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
-            # the damper command tracks a supply-air-flow setpoint).
-            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
-        )
-    )
+    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
     actuators = Node(cls=core.namespace.BRICK.Command)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     timeseries_id = Node(cls=core.namespace.XSD.string)
@@ -1541,14 +1534,7 @@ def brick_signature_pattern_vav_damper():
             core.namespace.BRICK.Supply_Air_Flow_Sensor,
         )
     )
-    setpoints = Node(
-        cls=(
-            core.namespace.BRICK.Zone_Air_Temperature_Setpoint,
-            # Flow-controlled VAV dampers (e.g. BMS-derived graphs where
-            # the damper command tracks a supply-air-flow setpoint).
-            core.namespace.BRICK.Supply_Air_Flow_Setpoint,
-        )
-    )
+    setpoints = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Setpoint)
     damper_equip = Node(cls=core.namespace.BRICK.Damper)
     damper_cmd = Node(cls=core.namespace.BRICK.Damper_Position_Setpoint)
     externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))

--- a/twin4build/systems/outdoor_environment/outdoor_environment_system.py
+++ b/twin4build/systems/outdoor_environment/outdoor_environment_system.py
@@ -215,6 +215,7 @@ class OutdoorEnvironmentSystem(core.System, nn.Module):
         # add a dedicated entry in :data:`TRANSFORMATIONS` and extend
         # this hook with feed-specific setters.
         self._transformation_outdoorTemperature = None
+        self._transformation_globalIrradiation = None
         self.cached_initialize_arguments = []
         self.cache_root = get_main_dir()
 
@@ -594,6 +595,7 @@ class OutdoorEnvironmentSystem(core.System, nn.Module):
                 use_database=self.use_database,
                 uuid=self.uuid_globalIrradiation,
                 dbconfig=self.dbconfig_globalIrradiation,
+                transformation=self._transformation_globalIrradiation,
                 # cache=False,
             )
             time_series_irrad.initialize(start_time, end_time, step_size)
@@ -728,6 +730,29 @@ class OutdoorEnvironmentSystem(core.System, nn.Module):
         """
         self._transformation_outdoorTemperature = fn
 
+    def set_transformation_by_type(self, semantic_type, fn):
+        """Route a per-Brick-class transformation to the matching feed.
+
+        :meth:`Model.set_transformations` calls this once per semantic
+        node the component models, with the class whose rule won for
+        that node: temperature-sensor classes go to the
+        ``outdoorTemperature`` feed, solar radiance / irradiance classes
+        to the ``globalIrradiation`` feed (e.g. clipping the spikes a
+        BMS irradiance sensor logs).  Unknown classes are ignored.
+        """
+        uris = {str(semantic_type.uri)} | {
+            str(c.uri) for c in getattr(semantic_type, "super_classes", [])
+        }
+        brick = core.namespace.BRICK
+        if str(brick.Temperature_Sensor) in uris:
+            self._transformation_outdoorTemperature = fn
+        elif uris & {
+            str(brick.Solar_Irradiance_Sensor),
+            str(brick.Solar_Radiance_Sensor),
+            str(brick.Global_Solar_Irradiation_Sensor),
+        }:
+            self._transformation_globalIrradiation = fn
+
     def _apply(self, x):
         return x * self.a.get() + self.b.get()
 
@@ -793,7 +818,15 @@ def brick_signature_pattern():
     """
     weather_station = Node(cls=core.namespace.BRICK.Weather_Station)
     temp = Node(cls=core.namespace.BRICK.Outside_Air_Temperature_Sensor)
-    irrad = Node(cls=core.namespace.BRICK.Global_Solar_Irradiation_Sensor)
+    irrad = Node(
+        cls=(
+            # ``Global_Solar_Irradiation_Sensor`` is not a Brick class (it
+            # survives for graphs that extend Brick with it);
+            # ``Solar_Irradiance_Sensor`` is the Brick 1.4 class (W/m2).
+            core.namespace.BRICK.Global_Solar_Irradiation_Sensor,
+            core.namespace.BRICK.Solar_Irradiance_Sensor,
+        )
+    )
     externalref_temp = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     externalref_irrad = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     timeseriesid_temp = Node(cls=core.namespace.XSD.string)
@@ -877,7 +910,15 @@ def brick_signature_pattern_standalone():
     sensor's external reference timeseries ID.
     """
     temp = Node(cls=core.namespace.BRICK.Outside_Air_Temperature_Sensor)
-    irrad = Node(cls=core.namespace.BRICK.Global_Solar_Irradiation_Sensor)
+    irrad = Node(
+        cls=(
+            # ``Global_Solar_Irradiation_Sensor`` is not a Brick class (it
+            # survives for graphs that extend Brick with it);
+            # ``Solar_Irradiance_Sensor`` is the Brick 1.4 class (W/m2).
+            core.namespace.BRICK.Global_Solar_Irradiation_Sensor,
+            core.namespace.BRICK.Solar_Irradiance_Sensor,
+        )
+    )
     externalref_temp = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     externalref_irrad = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
     timeseriesid_temp = Node(cls=core.namespace.XSD.string)

--- a/twin4build/systems/sensor/sensor_system.py
+++ b/twin4build/systems/sensor/sensor_system.py
@@ -606,6 +606,11 @@ def get_brick_zone_air_temp_sensor_with_ref_pattern():
         cls=(
             core.namespace.BRICK.Room,
             core.namespace.BRICK.HVAC_Zone,
+            # Brick 1.4 deprecates its location classes in favour of
+            # RealEstateCore (``brick:Room brick:isReplacedBy rec:Room``,
+            # ``brick:HVAC_Zone`` -> ``rec:HVACZone`` < ``rec:Zone``).
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
             core.namespace.BRICK.Enclosed_space,
             core.namespace.BRICK.Open_space,
         )
@@ -671,6 +676,11 @@ def get_brick_zone_air_temp_sensor_virtual_pattern():
         cls=(
             core.namespace.BRICK.Room,
             core.namespace.BRICK.HVAC_Zone,
+            # Brick 1.4 deprecates its location classes in favour of
+            # RealEstateCore (``brick:Room brick:isReplacedBy rec:Room``,
+            # ``brick:HVAC_Zone`` -> ``rec:HVACZone`` < ``rec:Zone``).
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
             core.namespace.BRICK.Enclosed_space,
             core.namespace.BRICK.Open_space,
         )
@@ -693,6 +703,127 @@ def get_brick_zone_air_temp_sensor_virtual_pattern():
     )
     sp.add_connection(room, "indoorTemperature", "measuredValue")
     sp.add_modeled_node(sensor)
+    return sp
+
+
+def _brick_room_classes():
+    return (
+        core.namespace.BRICK.Room,
+        core.namespace.BRICK.HVAC_Zone,
+        core.namespace.BRICK.Enclosed_space,
+        core.namespace.BRICK.Open_space,
+        core.namespace.REC.Room,
+        core.namespace.REC.Zone,
+    )
+
+
+def get_brick_room_zone_air_temp_sensor_with_ref_pattern():
+    """BRICK Zone_Air_Temperature_Sensor attached to the *room*, with a timeseries reference.
+
+    BMS-derived graphs (e.g. Hoeje-Taastrup Raadhus) hang the zone
+    temperature sensor off the room rather than off the VAV serving it::
+
+        Zone_Air_Temperature_Sensor  isPointOf             Room / Zone
+        Zone_Air_Temperature_Sensor  hasExternalReference  <ExternalRef/BNode>
+                                                                +- hasTimeseriesId -> <uuid>
+
+    Same wiring as :func:`get_brick_zone_air_temp_sensor_with_ref_pattern`
+    (``room.indoorTemperature -> sensor.measuredValue``); paired with
+    :func:`get_brick_room_zone_air_temp_sensor_virtual_pattern` following
+    the two-pattern split explained above.
+    """
+    sensor = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Sensor)
+    room = Node(cls=_brick_room_classes())
+    externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
+    timeseries_id = Node(cls=core.namespace.XSD.string)
+
+    sp = SignaturePattern(id="brick_room_zone_air_temp_sensor_with_ref_pattern")
+    sp.add_rule(
+        StepRule(subject=sensor, object=room, predicate=core.namespace.BRICK.isPointOf)
+    )
+    sp.add_rule(
+        StepRule(
+            subject=sensor,
+            object=externalref,
+            predicate=core.namespace.BRICKREF.hasExternalReference,
+        )
+    )
+    sp.add_rule(
+        StepRule(
+            subject=externalref,
+            object=timeseries_id,
+            predicate=core.namespace.BRICKREF.hasTimeseriesId,
+        )
+    )
+    sp.add_parameter("uuid", timeseries_id)
+    sp.add_connection(room, "indoorTemperature", "measuredValue")
+    sp.add_modeled_node(sensor)
+    sp.add_modeled_node(externalref)
+    return sp
+
+
+def get_brick_room_zone_air_temp_sensor_virtual_pattern():
+    """BRICK Zone_Air_Temperature_Sensor attached to the *room*, no timeseries reference.
+
+    Topology::
+
+        Zone_Air_Temperature_Sensor  isPointOf  Room / Zone
+
+    Mutually exclusive with
+    :func:`get_brick_room_zone_air_temp_sensor_with_ref_pattern` via the
+    shared ``sensor`` modeled node; the with-ref variant wins when both match.
+    """
+    sensor = Node(cls=core.namespace.BRICK.Zone_Air_Temperature_Sensor)
+    room = Node(cls=_brick_room_classes())
+
+    sp = SignaturePattern(id="brick_room_zone_air_temp_sensor_virtual_pattern")
+    sp.add_rule(
+        StepRule(subject=sensor, object=room, predicate=core.namespace.BRICK.isPointOf)
+    )
+    sp.add_connection(room, "indoorTemperature", "measuredValue")
+    sp.add_modeled_node(sensor)
+    return sp
+
+
+def get_brick_room_zone_co2_sensor_with_ref_pattern():
+    """BRICK Zone_CO2_Level_Sensor attached to the room, with a timeseries reference.
+
+    Topology::
+
+        Zone_CO2_Level_Sensor  isPointOf             Room / Zone
+        Zone_CO2_Level_Sensor  hasExternalReference  <ExternalRef/BNode>
+                                                         +- hasTimeseriesId -> <uuid>
+
+    Wires the BuildingSpace mass-balance output ``indoorCO2`` into the
+    sensor so simulated and measured CO2 can be compared.
+    """
+    sensor = Node(cls=core.namespace.BRICK.Zone_CO2_Level_Sensor)
+    room = Node(cls=_brick_room_classes())
+    externalref = Node(cls=(core.namespace.BRICKREF.ExternalReference, core.BlankNode))
+    timeseries_id = Node(cls=core.namespace.XSD.string)
+
+    sp = SignaturePattern(id="brick_room_zone_co2_sensor_with_ref_pattern")
+    sp.add_rule(
+        StepRule(subject=sensor, object=room, predicate=core.namespace.BRICK.isPointOf)
+    )
+    sp.add_rule(
+        StepRule(
+            subject=sensor,
+            object=externalref,
+            predicate=core.namespace.BRICKREF.hasExternalReference,
+        )
+    )
+    sp.add_rule(
+        StepRule(
+            subject=externalref,
+            object=timeseries_id,
+            predicate=core.namespace.BRICKREF.hasTimeseriesId,
+        )
+    )
+    sp.add_parameter("uuid", timeseries_id)
+    sp.add_connection(room, "indoorCO2", "measuredValue")
+    sp.add_modeled_node(sensor)
+    sp.add_modeled_node(externalref)
     return sp
 
 
@@ -778,6 +909,11 @@ def get_brick_supply_air_flow_sensor_with_ref_pattern():
         cls=(
             core.namespace.BRICK.Room,
             core.namespace.BRICK.HVAC_Zone,
+            # Brick 1.4 deprecates its location classes in favour of
+            # RealEstateCore (``brick:Room brick:isReplacedBy rec:Room``,
+            # ``brick:HVAC_Zone`` -> ``rec:HVACZone`` < ``rec:Zone``).
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
             core.namespace.BRICK.Enclosed_space,
             core.namespace.BRICK.Open_space,
         )
@@ -849,6 +985,11 @@ def get_brick_supply_air_flow_sensor_virtual_pattern():
         cls=(
             core.namespace.BRICK.Room,
             core.namespace.BRICK.HVAC_Zone,
+            # Brick 1.4 deprecates its location classes in favour of
+            # RealEstateCore (``brick:Room brick:isReplacedBy rec:Room``,
+            # ``brick:HVAC_Zone`` -> ``rec:HVACZone`` < ``rec:Zone``).
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
             core.namespace.BRICK.Enclosed_space,
             core.namespace.BRICK.Open_space,
         )
@@ -969,6 +1110,9 @@ class SensorSystem(core.System):
         # split is required.
         get_brick_zone_air_temp_sensor_with_ref_pattern(),
         get_brick_zone_air_temp_sensor_virtual_pattern(),
+        get_brick_room_zone_air_temp_sensor_with_ref_pattern(),
+        get_brick_room_zone_air_temp_sensor_virtual_pattern(),
+        get_brick_room_zone_co2_sensor_with_ref_pattern(),
         get_brick_ahu_supply_air_temp_sensor_with_ref_pattern(),
         get_brick_ahu_supply_air_temp_sensor_virtual_pattern(),
         get_brick_supply_air_flow_sensor_with_ref_pattern(),

--- a/twin4build/systems/space_heater/space_heater_system.py
+++ b/twin4build/systems/space_heater/space_heater_system.py
@@ -19,6 +19,7 @@ from twin4build.translator.translator import (
     StepRule,
     AnyPathRule,
     Node,
+    ModeledNode,
     OptionalRule,
     SignaturePattern,
     PathRule,
@@ -728,6 +729,63 @@ def brick_signature_pattern():
     return sp
 
 
+def brick_signature_pattern_room_heating_command():
+    """BRICK pattern for a radiator driven by a room-level heating command.
+
+    BMS-derived graphs often carry no radiator equipment, no water-flow
+    sensor and no supply-temperature point: the only heating information on
+    a room is a valve command (Hoeje-Taastrup Raadhus: ``R08_01_MVV01``, a
+    ``brick:Heating_Command`` in percent).  This pattern models one space
+    heater per such command::
+
+        Room  hasPoint  Heating_Command   -> waterFlowRate  (valve command)
+        Room                              -> indoorTemperature
+
+    ``waterFlowRate`` is fed from the command's historised
+    :class:`SensorSystem` (the leaf pattern matches the same point), so the
+    caller supplies the percent -> kg/s conversion through
+    :meth:`Model.set_transformations` (a ``brick:Heating_Command`` rule)
+    and the nominal water temperature through
+    :meth:`Model.fill_missing_inputs` (``supplyWaterTemperature``); both are
+    site data the ontology does not carry.  ``UA`` and
+    ``thermalMassHeatCapacity`` are then estimable per room.
+
+    The delivered ``Power`` is consumed by the room: the BRICK building-space
+    patterns bind the same ``Heating_Command`` node and connect
+    ``Power -> heatGain`` (see
+    :func:`twin4build.systems.building_space.building_space_system._brick_space_pattern`).
+
+    The modeled identity is the multi-member group ``[space, heating_cmd]``:
+    multi-member groups are mutex-ed per fingerprint, so this component can
+    coexist with the :class:`BuildingSpaceSystem` modeled on ``space`` and
+    with the leaf :class:`SensorSystem` modeled on the command.
+    """
+    space = Node(
+        cls=(
+            core.namespace.BRICK.Room,
+            core.namespace.BRICK.HVAC_Zone,
+            core.namespace.BRICK.Enclosed_space,
+            core.namespace.BRICK.Open_space,
+            core.namespace.REC.Room,
+            core.namespace.REC.Zone,
+            core.namespace.BRICK.Space,
+        )
+    )
+    heating_cmd = Node(cls=core.namespace.BRICK.Heating_Command)
+
+    sp = SignaturePattern(id="space_heater_signature_pattern_brick_room_command")
+    sp.add_rule(
+        StepRule(
+            subject=space, object=heating_cmd, predicate=core.namespace.BRICK.hasPoint
+        )
+    )
+    sp.add_connection(heating_cmd, "measuredValue", "waterFlowRate")
+    sp.add_connection(space, "indoorTemperature", "indoorTemperature")
+    ModeledNode([space, heating_cmd])
+    return sp
+
+
+SpaceHeaterSystem.add_signature_pattern(brick_signature_pattern_room_heating_command())
 SpaceHeaterSystem.add_signature_pattern(brick_signature_pattern())
 SpaceHeaterSystem.add_signature_pattern(saref_signature_pattern())
 

--- a/twin4build/tests/systems/outdoor_environment/test_feed_transformations.py
+++ b/twin4build/tests/systems/outdoor_environment/test_feed_transformations.py
@@ -1,0 +1,49 @@
+"""``OutdoorEnvironmentSystem.set_transformation_by_type`` routes a
+per-Brick-class unit conversion to the matching feed.
+
+Before, only the outdoor-temperature feed could receive a transformation
+(``set_transformation``), so a rule keyed by ``Solar_Irradiance_Sensor``
+(e.g. clipping the 1e8 W/m2 spikes a BMS irradiance sensor logs) was
+silently dropped and ``Model.set_transformations`` picked a single rule per
+component even when the component models sensors of different classes.
+"""
+
+# Standard library imports
+import unittest
+
+# Local application imports
+import twin4build
+import twin4build.core as core
+from twin4build.model.semantic_model.semantic_model import SemanticModel
+from twin4build.systems.outdoor_environment.outdoor_environment_system import (
+    OutdoorEnvironmentSystem,
+)
+
+twin4build._IS_TESTING = True
+
+BRICK = core.namespace.BRICK
+
+
+class TestFeedTransformations(unittest.TestCase):
+    def test_rules_reach_their_feeds(self):
+        sm = SemanticModel(id="feed_transformations")
+        outdoor = OutdoorEnvironmentSystem(id="outdoor")
+        clip = lambda x: min(x, 1500.0)  # noqa: E731
+        f2c = lambda x: (x - 32) * 5 / 9  # noqa: E731
+
+        outdoor.set_transformation_by_type(sm.get_type(BRICK.Solar_Irradiance_Sensor), clip)
+        outdoor.set_transformation_by_type(sm.get_type(BRICK.Outside_Air_Temperature_Sensor), f2c)
+        self.assertIs(outdoor._transformation_globalIrradiation, clip)
+        self.assertIs(outdoor._transformation_outdoorTemperature, f2c)
+
+        # A rule keyed by the generic Temperature_Sensor still reaches the
+        # temperature feed (subclass dispatch happens in Model).
+        outdoor.set_transformation_by_type(sm.get_type(BRICK.Temperature_Sensor), clip)
+        self.assertIs(outdoor._transformation_outdoorTemperature, clip)
+        # Unrelated classes are ignored.
+        outdoor.set_transformation_by_type(sm.get_type(BRICK.CO2_Sensor), f2c)
+        self.assertIs(outdoor._transformation_globalIrradiation, clip)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/twin4build/tests/translator/test_brick14_bms_patterns.py
+++ b/twin4build/tests/translator/test_brick14_bms_patterns.py
@@ -1,0 +1,168 @@
+"""End-to-end translation of a small Brick 1.4 / BMS-style graph.
+
+Mirrors the topology of the Hoeje-Taastrup Raadhus graph: rooms are
+``rec:Room``, the VAV carries its ``Damper_Position_Command`` as a direct
+point (no ``brick:Damper`` equipment), the zone temperature / CO2 sensors
+hang off the room, and the weather station has a
+``brick:Solar_Irradiance_Sensor``.  Before the pattern additions none of
+BuildingSpace / AirHandlingUnit / OutdoorEnvironment matched.
+"""
+
+# Standard library imports
+import os
+import shutil
+import unittest
+
+# Third party imports
+from rdflib import RDF, BNode, Literal, Namespace, URIRef
+
+# Local application imports
+import twin4build
+import twin4build.core as core
+from twin4build.model.semantic_model.semantic_model import SemanticModel
+from twin4build.systems.air_handling_unit.air_handling_unit_system import (
+    AirHandlingUnitSystem,
+)
+from twin4build.systems.building_space.building_space_system import (
+    BuildingSpaceSystem,
+)
+from twin4build.systems.outdoor_environment.outdoor_environment_system import (
+    OutdoorEnvironmentSystem,
+)
+from twin4build.systems.sensor.sensor_system import SensorSystem
+from twin4build.translator.translator import Translator
+
+twin4build._IS_TESTING = True
+
+BRICK = core.namespace.BRICK
+REC = core.namespace.REC
+REF = core.namespace.BRICKREF
+EX = Namespace("http://example.org/htr#")
+
+
+def _point(g, owner, name, cls, tsid=True):
+    p = EX[name]
+    g.add((owner, BRICK.hasPoint, p))
+    g.add((p, RDF.type, cls))
+    if tsid:
+        ref = EX[name + "_ref"]
+        g.add((p, REF.hasExternalReference, ref))
+        g.add((ref, RDF.type, REF.TimeseriesReference))
+        g.add((ref, REF.hasTimeseriesId, Literal(name)))
+    return p
+
+
+def build_graph(sm):
+    g = sm.instance_graph
+    ahu, ws = EX.AHU01, EX.WS01
+    g.add((ahu, RDF.type, BRICK.AHU))
+    _point(g, ahu, "AHU01_SAT", BRICK.Supply_Air_Temperature_Sensor)
+    _point(g, ahu, "AHU01_SAT_SP", BRICK.Supply_Air_Temperature_Setpoint)
+    g.add((ws, RDF.type, BRICK.Weather_Station))
+    _point(g, ws, "WS01_TOUT", BRICK.Outside_Air_Temperature_Sensor)
+    _point(g, ws, "WS01_SOLAR", BRICK.Solar_Irradiance_Sensor)
+    for i in (1, 2):
+        room, vav = EX[f"R0{i}"], EX[f"R0{i}_VAV01"]
+        g.add((room, RDF.type, REC.Room))
+        vol = BNode()
+        g.add((room, BRICK.volume, vol))
+        g.add((vol, BRICK.value, Literal(20.0 + i)))
+        g.add((vav, RDF.type, BRICK.VAV))
+        g.add((ahu, BRICK.feeds, vav))
+        g.add((vav, BRICK.feeds, room))
+        _point(g, vav, f"R0{i}_VAV01_CMD", BRICK.Damper_Position_Command)
+        _point(g, vav, f"R0{i}_FCI01", BRICK.Supply_Air_Flow_Sensor)
+        _point(g, room, f"R0{i}_TRU01", BRICK.Zone_Air_Temperature_Sensor)
+        _point(g, room, f"R0{i}_CO201", BRICK.Zone_CO2_Level_Sensor)
+    # ``isPointOf`` is only materialised by the reasoner from ``hasPoint``
+    # (owl:inverseOf) -- the patterns rely on that, as for real graphs.
+
+
+class TestBrick14BmsPatterns(unittest.TestCase):
+    MODEL_ID = "test_brick14_bms_patterns"
+
+    def tearDown(self):
+        path = os.path.join("generated_files", "models", self.MODEL_ID)
+        if os.path.exists(path):
+            shutil.rmtree(path)
+
+    def test_translation_matches_physics_and_sensors(self):
+        sm = SemanticModel(id=self.MODEL_ID, namespaces={"ex": str(EX)})
+        build_graph(sm)
+        model = Translator().translate(
+            sm,
+            systems=[
+                BuildingSpaceSystem,
+                AirHandlingUnitSystem,
+                OutdoorEnvironmentSystem,
+                SensorSystem,
+            ],
+            id=self.MODEL_ID,
+        )
+        by_cls = {}
+        for c in model.components.values():
+            by_cls.setdefault(type(c).__name__, []).append(c)
+
+        # Rooms model the ``rec:Room`` node plus the ``brick:volume`` blank
+        # node, so the id is the composite ``[<bnode>][R0i]`` form; resolve
+        # them through the translator's sim -> sem map instead.
+        translator = model._translator
+        rooms = {}
+        for c in by_cls["BuildingSpaceSystem"]:
+            uris = {str(n.uri) for n in translator.sim2sem_map[c]}
+            (room_uri,) = [u for u in uris if u.startswith(str(EX))]
+            rooms[room_uri.split("#")[-1]] = c
+        self.assertEqual(sorted(rooms), ["R01", "R02"])
+        self.assertEqual(len(by_cls["AirHandlingUnitSystem"]), 1)
+        self.assertEqual(len(by_cls["OutdoorEnvironmentSystem"]), 1)
+
+        def incoming(comp, port):
+            for cp in comp.connects_at:
+                if cp.input_port == port:
+                    return [conn.connects_system for conn in cp.connects_system_through]
+            return []
+
+        ahu = by_cls["AirHandlingUnitSystem"][0]
+        for room in rooms.values():
+            self.assertEqual(incoming(room, "supplyAirFlowRate"), [ahu])
+            # Coil-less VAV: the room breathes AHU supply air directly.
+            self.assertEqual(incoming(room, "supplyAirTemperature"), [ahu])
+            self.assertEqual(
+                [type(c).__name__ for c in incoming(room, "outdoorTemperature")],
+                ["OutdoorEnvironmentSystem"],
+            )
+        # Room volume read from ``brick:volume [brick:value x]``.
+        self.assertAlmostEqual(float(rooms["R01"].mass.V.get()), 21.0)
+        self.assertAlmostEqual(float(rooms["R02"].mass.V.get()), 22.0)
+        self.assertEqual(len(incoming(ahu, "exhaustTemperature")), 2)
+        self.assertEqual(
+            [c.uuid for c in incoming(ahu, "supplyAirTemperatureSetpoint")],
+            ["AHU01_SAT_SP"],
+        )
+
+        # Room-attached zone sensors are wired to the modelled room state.
+        sensors = {c.uuid: c for c in by_cls["SensorSystem"] if c.uuid}
+        for i in (1, 2):
+            self.assertEqual(incoming(sensors[f"R0{i}_TRU01"], "measuredValue"), [rooms[f"R0{i}"]])
+            self.assertEqual(incoming(sensors[f"R0{i}_CO201"], "measuredValue"), [rooms[f"R0{i}"]])
+            self.assertEqual(incoming(sensors[f"R0{i}_FCI01"], "measuredValue"), [ahu])
+        self.assertEqual(incoming(sensors["AHU01_SAT"], "measuredValue"), [ahu])
+
+        outdoor = by_cls["OutdoorEnvironmentSystem"][0]
+        self.assertEqual(outdoor.uuid_outdoorTemperature, "WS01_TOUT")
+        self.assertEqual(outdoor.uuid_globalIrradiation, "WS01_SOLAR")
+        # Per-feed transformation dispatch: the irradiance rule must reach
+        # the irradiation feed, the temperature rule the temperature feed.
+        clip = lambda x: min(x, 1500.0)  # noqa: E731
+        f2c = lambda x: (x - 32) * 5 / 9  # noqa: E731
+        model.set_transformations(
+            {BRICK.Solar_Irradiance_Sensor: clip, BRICK.Temperature_Sensor: f2c}
+        )
+        self.assertIs(outdoor._transformation_globalIrradiation, clip)
+        self.assertIs(outdoor._transformation_outdoorTemperature, f2c)
+        # The vendored Brick ``ref`` schema parses offline.
+        self.assertNotIn(str(REF), sm.error_namespaces)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/twin4build/tests/translator/test_brick14_bms_patterns.py
+++ b/twin4build/tests/translator/test_brick14_bms_patterns.py
@@ -26,6 +26,9 @@ from twin4build.systems.air_handling_unit.air_handling_unit_system import (
 from twin4build.systems.building_space.building_space_system import (
     BuildingSpaceSystem,
 )
+from twin4build.systems.controller.controller_identification.controller_identification_pi_system import (
+    ControllerIdentificationPISystem,
+)
 from twin4build.systems.outdoor_environment.outdoor_environment_system import (
     OutdoorEnvironmentSystem,
 )
@@ -72,10 +75,31 @@ def build_graph(sm):
         g.add((vav, BRICK.feeds, room))
         _point(g, vav, f"R0{i}_VAV01_CMD", BRICK.Damper_Position_Command)
         _point(g, vav, f"R0{i}_FCI01", BRICK.Supply_Air_Flow_Sensor)
+        _point(g, vav, f"R0{i}_SpFCI01_C", BRICK.Supply_Air_Flow_Setpoint)
         _point(g, room, f"R0{i}_TRU01", BRICK.Zone_Air_Temperature_Sensor)
+        _point(g, room, f"R0{i}_SpTRU01", BRICK.Zone_Air_Temperature_Setpoint)
+        _point(g, room, f"R0{i}_SpTRU01_K", BRICK.Zone_Air_Cooling_Temperature_Setpoint)
         _point(g, room, f"R0{i}_CO201", BRICK.Zone_CO2_Level_Sensor)
+    # A second VAV on room R02 (HTR rooms have up to four): each VAV must
+    # get its own controller although they share the room's sensor and
+    # setpoints (regression: the walker used to keep one match per room).
+    vav2 = EX["R02_VAV02"]
+    g.add((vav2, RDF.type, BRICK.VAV))
+    g.add((ahu, BRICK.feeds, vav2))
+    g.add((vav2, BRICK.feeds, EX["R02"]))
+    _point(g, vav2, "R02_VAV02_CMD", BRICK.Damper_Position_Command)
+    _point(g, vav2, "R02_FCI02", BRICK.Supply_Air_Flow_Sensor)
+    _point(g, vav2, "R02_SpFCI02_C", BRICK.Supply_Air_Flow_Setpoint)
     # ``isPointOf`` is only materialised by the reasoner from ``hasPoint``
     # (owl:inverseOf) -- the patterns rely on that, as for real graphs.
+
+
+def _outgoing_components(component, port):
+    out = []
+    for conn in component.connected_through:
+        if conn.output_port == port:
+            out.extend(cp.connection_point_of for cp in conn.connects_system_at)
+    return out
 
 
 class TestBrick14BmsPatterns(unittest.TestCase):
@@ -96,6 +120,7 @@ class TestBrick14BmsPatterns(unittest.TestCase):
                 AirHandlingUnitSystem,
                 OutdoorEnvironmentSystem,
                 SensorSystem,
+                ControllerIdentificationPISystem,
             ],
             id=self.MODEL_ID,
         )
@@ -134,7 +159,7 @@ class TestBrick14BmsPatterns(unittest.TestCase):
         # Room volume read from ``brick:volume [brick:value x]``.
         self.assertAlmostEqual(float(rooms["R01"].mass.V.get()), 21.0)
         self.assertAlmostEqual(float(rooms["R02"].mass.V.get()), 22.0)
-        self.assertEqual(len(incoming(ahu, "exhaustTemperature")), 2)
+        self.assertEqual(len(incoming(ahu, "exhaustTemperature")), 2)  # one slot per room
         self.assertEqual(
             [c.uuid for c in incoming(ahu, "supplyAirTemperatureSetpoint")],
             ["AHU01_SAT_SP"],
@@ -147,6 +172,29 @@ class TestBrick14BmsPatterns(unittest.TestCase):
             self.assertEqual(incoming(sensors[f"R0{i}_CO201"], "measuredValue"), [rooms[f"R0{i}"]])
             self.assertEqual(incoming(sensors[f"R0{i}_FCI01"], "measuredValue"), [ahu])
         self.assertEqual(incoming(sensors["AHU01_SAT"], "measuredValue"), [ahu])
+
+        # One PI-CITS per VAV, with the loop variables taken from the room:
+        # zone temperature sensor -> sensorValue, zone temperature setpoints
+        # -> setpointValue, and the VAV flow setpoint on the gate bus.
+        cits_list = by_cls["ControllerIdentificationPISystem"]
+        self.assertEqual(len(cits_list), 3)  # R01_VAV01, R02_VAV01, R02_VAV02
+        gates = []
+        for cits in cits_list:
+            uuids = lambda port: sorted(c.uuid for c in incoming(cits, port))  # noqa: E731
+            (sensor_uuid,) = uuids("sensorValue")
+            i = sensor_uuid[2]  # R0<i>_TRU01
+            self.assertEqual(sensor_uuid, f"R0{i}_TRU01")
+            self.assertEqual(uuids("setpointValue"), [f"R0{i}_SpTRU01", f"R0{i}_SpTRU01_K"])
+            (gate,) = uuids("onOffSignal")
+            gates.append(gate)
+            # Every controller feeds its historised command sensor ...
+            downstream = _outgoing_components(cits, "inputSignal")
+            self.assertTrue(any(isinstance(c, SensorSystem) for c in downstream))
+        self.assertEqual(sorted(gates), ["R01_SpFCI01_C", "R02_SpFCI01_C", "R02_SpFCI02_C"])
+        # ... and the AHU damper slot of each room is driven by exactly one
+        # of that room's controllers (one connection per Vector slot).
+        drivers = [c for c in cits_list if ahu in _outgoing_components(c, "inputSignal")]
+        self.assertEqual(len(drivers), 2)
 
         outdoor = by_cls["OutdoorEnvironmentSystem"][0]
         self.assertEqual(outdoor.uuid_outdoorTemperature, "WS01_TOUT")

--- a/twin4build/tests/translator/test_brick14_bms_patterns.py
+++ b/twin4build/tests/translator/test_brick14_bms_patterns.py
@@ -191,10 +191,15 @@ class TestBrick14BmsPatterns(unittest.TestCase):
             downstream = _outgoing_components(cits, "inputSignal")
             self.assertTrue(any(isinstance(c, SensorSystem) for c in downstream))
         self.assertEqual(sorted(gates), ["R01_SpFCI01_C", "R02_SpFCI01_C", "R02_SpFCI02_C"])
-        # ... and the AHU damper slot of each room is driven by exactly one
-        # of that room's controllers (one connection per Vector slot).
-        drivers = [c for c in cits_list if ahu in _outgoing_components(c, "inputSignal")]
-        self.assertEqual(len(drivers), 2)
+        # ... and each AHU damper Vector gets exactly one input per room slot,
+        # sourced from a controller.  Which VAV of a room drives which of the
+        # two damper vectors is up to the MILP, so only the per-slot
+        # invariant is asserted.
+        for port in ("supplyDamperPosition", "exhaustDamperPosition"):
+            sources = incoming(ahu, port)
+            self.assertEqual(len(sources), 2, port)  # one per room
+            for src in sources:
+                self.assertIsInstance(src, ControllerIdentificationPISystem)
 
         outdoor = by_cls["OutdoorEnvironmentSystem"][0]
         self.assertEqual(outdoor.uuid_outdoorTemperature, "WS01_TOUT")

--- a/twin4build/tests/translator/test_brick14_bms_patterns.py
+++ b/twin4build/tests/translator/test_brick14_bms_patterns.py
@@ -195,6 +195,25 @@ class TestBrick14BmsPatterns(unittest.TestCase):
         # of that room's controllers (one connection per Vector slot).
         drivers = [c for c in cits_list if ahu in _outgoing_components(c, "inputSignal")]
         self.assertEqual(len(drivers), 2)
+        # ... and both damper ports of a zone slot are driven by the SAME
+        # controller.  Constraint 4 of the MILP bounds each port on its own,
+        # so R02's two VAVs could split that zone's ports between them, an
+        # equally optimal solution that solver tie-breaking picked on some
+        # platforms (three drivers instead of two); the slot-coherence
+        # constraint (4b) rules it out for every solver.
+        driver_by_slot = {}
+        for cp in ahu.connects_at:
+            if cp.input_port not in ("supplyDamperPosition", "exhaustDamperPosition"):
+                continue
+            for conn in cp.connects_system_through:
+                slot = int(cp.input_port_index[conn])
+                driver_by_slot.setdefault(slot, {})[cp.input_port] = conn.connects_system
+        self.assertEqual(len(driver_by_slot), 2)  # one slot per room
+        for slot, ports in driver_by_slot.items():
+            self.assertEqual(
+                set(ports), {"supplyDamperPosition", "exhaustDamperPosition"}, slot
+            )
+            self.assertIs(ports["supplyDamperPosition"], ports["exhaustDamperPosition"])
 
         outdoor = by_cls["OutdoorEnvironmentSystem"][0]
         self.assertEqual(outdoor.uuid_outdoorTemperature, "WS01_TOUT")

--- a/twin4build/tests/translator/test_offline_translation.py
+++ b/twin4build/tests/translator/test_offline_translation.py
@@ -39,9 +39,11 @@ EXPECTED_COMPONENTS = [
     "office_space_heater",
     "office_space_heater_valve",
     "office_supply_damper",
-    # Consumer-less schedule matched from the spreadsheet; kept since the
-    # translator retains stand-alone (input-free) components.
-    "office_temperature_cooling_system_setpoint",
+    # "office_temperature_cooling_system_setpoint" is matched from the
+    # spreadsheet but has no consumer and no data source (none of its
+    # use_spreadsheet / use_database / use_dict flags), so it cannot simulate
+    # and stays dropped: stand-alone components are kept only when they can
+    # run on their own.
     "office_temperature_heating_controller",
     "office_temperature_heating_setpoint",
     "office_temperature_sensor",

--- a/twin4build/tests/translator/test_offline_translation.py
+++ b/twin4build/tests/translator/test_offline_translation.py
@@ -39,6 +39,9 @@ EXPECTED_COMPONENTS = [
     "office_space_heater",
     "office_space_heater_valve",
     "office_supply_damper",
+    # Consumer-less schedule matched from the spreadsheet; kept since the
+    # translator retains stand-alone (input-free) components.
+    "office_temperature_cooling_system_setpoint",
     "office_temperature_heating_controller",
     "office_temperature_heating_setpoint",
     "office_temperature_sensor",

--- a/twin4build/tests/translator/test_space_heater_room_command.py
+++ b/twin4build/tests/translator/test_space_heater_room_command.py
@@ -1,0 +1,125 @@
+"""Room-level radiator from a BRICK ``Heating_Command``.
+
+BMS-derived graphs often carry no radiator equipment, no water-flow sensor
+and no supply-temperature point: the only heating information on a room is a
+valve command (Hoeje-Taastrup Raadhus: ``R08_01_MVV01``).  The pattern under
+test turns that into one :class:`SpaceHeaterSystem` per room, fed by the
+command's historised sensor, and the delivered ``Power`` becomes the room's
+``heatGain``.
+"""
+
+# Standard library imports
+import os
+import shutil
+import unittest
+
+# Third party imports
+from rdflib import RDF, BNode, Literal, Namespace
+
+# Local application imports
+import twin4build
+import twin4build.core as core
+from twin4build.model.semantic_model.semantic_model import SemanticModel
+from twin4build.systems.air_handling_unit.air_handling_unit_system import (
+    AirHandlingUnitSystem,
+)
+from twin4build.systems.building_space.building_space_system import (
+    BuildingSpaceSystem,
+)
+from twin4build.systems.sensor.sensor_system import SensorSystem
+from twin4build.systems.space_heater.space_heater_system import SpaceHeaterSystem
+from twin4build.translator.translator import Translator
+
+twin4build._IS_TESTING = True
+
+BRICK = core.namespace.BRICK
+REC = core.namespace.REC
+REF = core.namespace.BRICKREF
+EX = Namespace("http://example.org/heating#")
+
+
+def _point(g, owner, name, cls):
+    p = EX[name]
+    g.add((owner, BRICK.hasPoint, p))
+    g.add((p, RDF.type, cls))
+    ref = BNode()
+    g.add((p, REF.hasExternalReference, ref))
+    g.add((ref, RDF.type, REF.TimeseriesReference))
+    g.add((ref, REF.hasTimeseriesId, Literal(name)))
+    return p
+
+
+def _graph(sm):
+    """Two rooms served by one AHU; only R01 has a radiator valve command."""
+    g = sm.instance_graph
+    g.add((EX.AHU01, RDF.type, BRICK.AHU))
+    for i in (1, 2):
+        room, vav = EX[f"R0{i}"], EX[f"R0{i}_VAV01"]
+        g.add((room, RDF.type, REC.Room))
+        g.add((vav, RDF.type, BRICK.VAV))
+        g.add((EX.AHU01, BRICK.feeds, vav))
+        g.add((vav, BRICK.feeds, room))
+        _point(g, vav, f"R0{i}_VAV01_CMD", BRICK.Damper_Position_Command)
+        _point(g, room, f"R0{i}_TRU01", BRICK.Zone_Air_Temperature_Sensor)
+    _point(g, EX["R01"], "R01_MVV01", BRICK.Heating_Command)
+
+
+def _incoming(component, port):
+    for cp in component.connects_at:
+        if cp.input_port == port:
+            return [conn.connects_system for conn in cp.connects_system_through]
+    return []
+
+
+class TestSpaceHeaterFromRoomHeatingCommand(unittest.TestCase):
+    MODEL_ID = "test_space_heater_room_command"
+
+    def tearDown(self):
+        path = os.path.join("generated_files", "models", self.MODEL_ID)
+        if os.path.exists(path):
+            shutil.rmtree(path)
+
+    def test_radiator_is_wired_to_room_and_command(self):
+        sm = SemanticModel(id=self.MODEL_ID, namespaces={"ex": str(EX)})
+        _graph(sm)
+        model = Translator().translate(
+            sm,
+            systems=[
+                BuildingSpaceSystem,
+                AirHandlingUnitSystem,
+                SpaceHeaterSystem,
+                SensorSystem,
+            ],
+            id=self.MODEL_ID,
+        )
+        heaters = model.get_components_by_class(SpaceHeaterSystem)
+        rooms = model.get_components_by_class(BuildingSpaceSystem)
+        self.assertEqual(len(rooms), 2)
+        # Only the room carrying a Heating_Command gets a radiator.
+        self.assertEqual(len(heaters), 1)
+        heater = heaters[0]
+
+        # Water side: the valve command's historised sensor (percent ->
+        # kg/s is a caller-side transformation, see Model.set_transformations).
+        flow_sources = _incoming(heater, "waterFlowRate")
+        self.assertEqual([type(c).__name__ for c in flow_sources], ["SensorSystem"])
+        self.assertEqual(flow_sources[0].uuid, "R01_MVV01")
+
+        # Air side: the room it heats, and the heat goes back into that room.
+        (room_in,) = _incoming(heater, "indoorTemperature")
+        self.assertIsInstance(room_in, BuildingSpaceSystem)
+        heated = [r for r in rooms if heater in _incoming(r, "heatGain")]
+        self.assertEqual(heated, [room_in])
+
+        # The room without a command keeps an unwired heatGain, so
+        # ``fill_missing_inputs`` can still supply a constant there.
+        unheated = [r for r in rooms if r is not room_in]
+        self.assertEqual(_incoming(unheated[0], "heatGain"), [])
+
+        # ``supplyWaterTemperature`` is not in the graph; it stays unwired for
+        # ``fill_missing_inputs``.
+        self.assertEqual(_incoming(heater, "supplyWaterTemperature"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/twin4build/tests/translator/test_unconnected_components.py
+++ b/twin4build/tests/translator/test_unconnected_components.py
@@ -1,0 +1,82 @@
+"""Regression test: MILP-active components without any connection must
+still be part of the translated model.
+
+``Translator._connect_components`` used to derive the set of "used"
+components from the active *connections* only.  A solution made of
+components that do not connect to anything -- e.g. Brick leaf sensors
+bound to a timeseries id through ``ref:hasExternalReference`` -- was
+therefore silently discarded: ``translate`` returned a ``Model`` with
+zero components and empty ``sim2sem`` / ``sem2sim`` maps.
+"""
+
+# Standard library imports
+import os
+import shutil
+import unittest
+
+# Third party imports
+from rdflib import RDF, BNode, Literal
+
+# Local application imports
+import twin4build
+import twin4build.core as core
+from twin4build.model.semantic_model.semantic_model import SemanticModel
+from twin4build.systems.sensor.sensor_system import SensorSystem
+from twin4build.translator.translator import Translator
+
+twin4build._IS_TESTING = True
+
+
+class TestUnconnectedComponentsAreKept(unittest.TestCase):
+    MODEL_ID = "test_unconnected_components"
+
+    def tearDown(self):
+        path = os.path.join("generated_files", "models", self.MODEL_ID)
+        if os.path.exists(path):
+            shutil.rmtree(path)
+
+    def test_leaf_sensors_survive_translation(self):
+        BRICK = core.namespace.BRICK
+        REF = core.namespace.BRICKREF
+        EX = core.namespace.T4B
+
+        sm = SemanticModel(id=self.MODEL_ID)
+        g = sm.instance_graph
+        expected_ids = []
+        for i in range(3):
+            sensor = EX[f"zone_temp_{i}"]
+            ref = BNode()
+            g.add((sensor, RDF.type, BRICK.Zone_Air_Temperature_Sensor))
+            g.add((sensor, REF.hasExternalReference, ref))
+            # Typed directly as ExternalReference so the test does not depend
+            # on the Brick ``ref`` ontology being available for subclass reasoning.
+            g.add((ref, RDF.type, REF.ExternalReference))
+            g.add((ref, REF.hasTimeseriesId, Literal(f"uuid-{i}")))
+            expected_ids.append(f"zone_temp_{i}")
+        # A sensor without any data source or upstream cannot be simulated
+        # and must still be dropped, as before.
+        g.add((EX["dangling_virtual"], RDF.type, BRICK.Zone_Air_Temperature_Sensor))
+
+        translator = Translator()
+        model = translator.translate(sm, systems=[SensorSystem], id=self.MODEL_ID)
+
+        components = model.components
+        self.assertEqual(len(components), 3, components)
+        self.assertNotIn("dangling_virtual", components)
+        for comp_id, comp in components.items():
+            self.assertIsInstance(comp, SensorSystem)
+        self.assertEqual(
+            sorted(c.uuid for c in components.values()),
+            ["uuid-0", "uuid-1", "uuid-2"],
+        )
+        # The translator-side maps must cover the unconnected components too.
+        self.assertEqual(len(translator.sim2sem_map), 3)
+        self.assertEqual(
+            set(translator.sim2sem_map.keys()), set(components.values())
+        )
+        for comp in components.values():
+            self.assertIn(comp, translator._sim2group_map)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/twin4build/tests/translator/test_unconnected_components.py
+++ b/twin4build/tests/translator/test_unconnected_components.py
@@ -77,6 +77,28 @@ class TestUnconnectedComponentsAreKept(unittest.TestCase):
         for comp in components.values():
             self.assertIn(comp, translator._sim2group_map)
 
+    def test_standalone_rule_requires_a_data_source(self):
+        """An input-free component is kept only if it can emit something.
+
+        A ScheduleSystem instantiated from a semantic node alone has none of
+        its source flags set and fails at simulation, so keeping it turns a
+        translatable model into one that cannot run (the full-workflow
+        example's consumer-less cooling setpoint).
+        """
+        import twin4build as tb
+        from twin4build.translator.translator import Translator
+
+        is_standalone = Translator._is_standalone_component
+        with_data = tb.ScheduleSystem(
+            weekday_ruleset={"ruleset_default_value": 21.0}, id="with_data"
+        )
+        self.assertTrue(is_standalone(with_data))
+        without_data = tb.ScheduleSystem(id="without_data")
+        self.assertFalse(is_standalone(without_data))
+        # Data-bound leaves stay standalone through their source binding.
+        self.assertTrue(is_standalone(SensorSystem(uuid="uuid-x", id="leaf")))
+        self.assertFalse(is_standalone(SensorSystem(id="virtual")))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/twin4build/tests/translator/test_walker_veto_and_hub_leak.py
+++ b/twin4build/tests/translator/test_walker_veto_and_hub_leak.py
@@ -1,0 +1,155 @@
+"""Two matcher regressions found on the Hoeje-Taastrup Raadhus graph.
+
+1. A stand-alone :class:`NoStepRule` (not ``&``-composed with a positive
+   rule) pruned every branch: with the predicate absent the walker hit the
+   "missing predicate" prune, with the predicate present but no forbidden
+   neighbour it hit the "no pair matched" prune.  The veto only ever worked
+   inside ``AnyPathRule & NoStepRule``.
+
+2. Bindings leaked between sibling matches through a shared hub: seeded at
+   room R01 the walker crossed ``R01 -> VAV -> AHU -> VAV -> R02`` and
+   carried R02's downstream literals (``brick:volume`` value) back into
+   R01's map, producing one component per room *per* literal.
+"""
+
+# Standard library imports
+import unittest
+
+# Third party imports
+from rdflib import RDF, BNode, Literal, Namespace
+
+# Local application imports
+import twin4build
+import twin4build.core as core
+from twin4build.model.semantic_model.semantic_model import SemanticModel
+from twin4build.systems.building_space.building_space_system import (
+    BuildingSpaceSystem,
+)
+from twin4build.translator.translator import (
+    Node,
+    NoStepRule,
+    Predicate,
+    SignaturePattern,
+    StepRule,
+    Translator,
+)
+
+twin4build._IS_TESTING = True
+
+BRICK = core.namespace.BRICK
+REC = core.namespace.REC
+EX = Namespace("http://example.org/walker#")
+
+
+def _graph(sm, reheat_room=None):
+    g = sm.instance_graph
+    g.add((EX.AHU01, RDF.type, BRICK.AHU))
+    for i in (1, 2):
+        room, vav = EX[f"R0{i}"], EX[f"R0{i}_VAV"]
+        g.add((room, RDF.type, REC.Room))
+        g.add((vav, RDF.type, BRICK.VAV))
+        g.add((EX.AHU01, BRICK.feeds, vav))
+        g.add((vav, BRICK.feeds, room))
+        g.add((vav, BRICK.hasPoint, EX[f"R0{i}_CMD"]))
+        g.add((EX[f"R0{i}_CMD"], RDF.type, BRICK.Damper_Position_Command))
+        vol = BNode()
+        g.add((room, BRICK.volume, vol))
+        g.add((vol, BRICK.value, Literal(20.0 + i)))
+        if reheat_room == i:
+            g.add((vav, BRICK.hasPoint, EX[f"R0{i}_REHEAT"]))
+            g.add((EX[f"R0{i}_REHEAT"], RDF.type, BRICK.Reheat_Command))
+
+
+def _pattern(veto_part=False, veto_point=False, with_volume=False):
+    ahu = Node(cls=BRICK.AHU)
+    vav = Node(cls=BRICK.VAV)
+    space = Node(cls=(REC.Room,))
+    feeds = Predicate((BRICK.feeds,))
+    sp = SignaturePattern(id=f"walker_probe_{veto_part}_{veto_point}_{with_volume}")
+    sp.add_rule(StepRule(subject=ahu, object=vav, predicate=feeds))
+    sp.add_rule(StepRule(subject=vav, object=space, predicate=feeds))
+    if veto_part:
+        sp.add_rule(
+            NoStepRule(
+                subject=vav,
+                object=Node(cls=(BRICK.Heating_Coil, BRICK.Cooling_Coil)),
+                predicate=BRICK.hasPart,
+            )
+        )
+    if veto_point:
+        sp.add_rule(
+            NoStepRule(
+                subject=vav,
+                object=Node(cls=(BRICK.Reheat_Command, BRICK.Valve_Command)),
+                predicate=BRICK.hasPoint,
+            )
+        )
+    if with_volume:
+        vol = Node(cls=(core.BlankNode,))
+        val = Node(cls=(core.namespace.XSD.float, core.namespace.XSD.double, core.namespace.XSD.decimal))
+        sp.add_rule(StepRule(subject=space, object=vol, predicate=BRICK.volume))
+        sp.add_rule(StepRule(subject=vol, object=val, predicate=BRICK.value))
+        sp.add_parameter("mass.V", val)
+        sp.add_modeled_node(vol)
+    sp.add_connection(ahu, "supplyAirTemperature", "supplyAirTemperature")
+    sp.add_modeled_node(space)
+    return sp, space
+
+
+class TestStandaloneNoStepRule(unittest.TestCase):
+    def _complete(self, sp, sm):
+        complete, _ = Translator._match_patterns([BuildingSpaceSystem], sm)
+        return complete[BuildingSpaceSystem].get(sp, [])
+
+    def setUp(self):
+        self._saved_sp = list(BuildingSpaceSystem.sp)
+
+    def tearDown(self):
+        BuildingSpaceSystem.sp = self._saved_sp
+
+    def test_veto_passes_when_predicate_absent(self):
+        sm = SemanticModel(id="veto_absent", namespaces={"ex": str(EX)})
+        _graph(sm)
+        sp, _ = _pattern(veto_part=True)  # no VAV has hasPart at all
+        BuildingSpaceSystem.sp = [sp]
+        self.assertEqual(len(self._complete(sp, sm)), 2)
+
+    def test_veto_passes_when_only_allowed_neighbours(self):
+        sm = SemanticModel(id="veto_allowed", namespaces={"ex": str(EX)})
+        _graph(sm)
+        sp, _ = _pattern(veto_point=True)  # hasPoint exists, but no reheat cmd
+        BuildingSpaceSystem.sp = [sp]
+        self.assertEqual(len(self._complete(sp, sm)), 2)
+
+    def test_veto_prunes_forbidden_neighbour(self):
+        sm = SemanticModel(id="veto_fires", namespaces={"ex": str(EX)})
+        _graph(sm, reheat_room=2)
+        sp, space = _pattern(veto_point=True)
+        BuildingSpaceSystem.sp = [sp]
+        groups = self._complete(sp, sm)
+        self.assertEqual([str(g[space].uri).split("#")[-1] for g in groups], ["R01"])
+
+
+class TestHubLeak(unittest.TestCase):
+    def setUp(self):
+        self._saved_sp = list(BuildingSpaceSystem.sp)
+
+    def tearDown(self):
+        BuildingSpaceSystem.sp = self._saved_sp
+
+    def test_literal_stays_with_its_room(self):
+        sm = SemanticModel(id="hub_leak", namespaces={"ex": str(EX)})
+        _graph(sm)
+        sp, space = _pattern(with_volume=True)
+        BuildingSpaceSystem.sp = [sp]
+        complete, _ = Translator._match_patterns([BuildingSpaceSystem], sm)
+        groups = complete[BuildingSpaceSystem][sp]
+        # One match per room, each carrying its own volume literal.
+        self.assertEqual(len(groups), 2)
+        val_node = sp.parameters["mass.V"]
+        bound = {str(g[space].uri).split("#")[-1]: float(g[val_node].uri) for g in groups}
+        self.assertEqual(bound, {"R01": 21.0, "R02": 22.0})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/twin4build/translator/translator.py
+++ b/twin4build/translator/translator.py
@@ -572,8 +572,15 @@ class Translator:
 
                 for sm_node in candidate_sm_nodes:
 
-                    # Initialize tracking structures for this DFS traversal
+                    # Initialize tracking structures for this DFS traversal.
+                    # The seed binding is recorded up front: otherwise the
+                    # seed stays unbound while its neighbourhood is
+                    # explored, a backward hop (room -> its VAVs) can bind
+                    # the seed's SP node to a *sibling* first, and the
+                    # seed's own descendants are then rejected as binding
+                    # conflicts (one match per room instead of one per VAV).
                     initial_map = {n: None for n in signature_pattern.nodes}
+                    initial_map[sp_node] = sm_node
                     feasible = {n: set() for n in signature_pattern.nodes}
                     comparison_table = {n: set() for n in signature_pattern.nodes}
                     candidate_maps = [Translator._copy_nodemap(initial_map)]

--- a/twin4build/translator/translator.py
+++ b/twin4build/translator/translator.py
@@ -2450,6 +2450,28 @@ class Translator:
         LOGGER.ok("Connecting components", change_status=True)
 
     @staticmethod
+    def _binding_compatible(bound: Any, sm_node: Any) -> bool:
+        """``sm_node`` may extend a map whose slot is unbound, bound to the
+        same node, or set-bound to a tuple containing it."""
+        if bound is None:
+            return True
+        if isinstance(bound, tuple):
+            return sm_node in bound or bound == sm_node
+        return bound == sm_node
+
+    @staticmethod
+    def _cached_descendants_consistent(
+        current_map: Dict[Node, Any], cached: Dict[Node, Any]
+    ) -> bool:
+        """True iff ``cached`` agrees with ``current_map`` on every node the
+        latter has already bound (see the descendant-cache back-fill)."""
+        for sp_n, sm_n in cached.items():
+            bound = current_map.get(sp_n)
+            if bound is not None and bound != sm_n:
+                return False
+        return True
+
+    @staticmethod
     def _copy_nodemap(nodemap: Dict[Node, Any]) -> Dict[Node, Any]:
         return {k: v for k, v in nodemap.items()}
 
@@ -2855,6 +2877,32 @@ class Translator:
         LOGGER.debug("Entering prune_recursive (bidirectional)")
         LOGGER.add_level()
         LOGGER.debug(lambda: Translator._get_node_string(sp_subject, sm_subject))
+        _diag_walker = _match_diag_enabled(signature_pattern)
+
+        # Binding-consistency guard.  A candidate map that already binds
+        # ``sp_subject`` to a *different* SM node cannot be extended through
+        # this SM node: the walker would otherwise carry the descendants of
+        # a sibling match back up through a shared hub (one AHU feeding
+        # several rooms) and, when the hub level re-assigns ``sp_subject``,
+        # leave those foreign descendants in the map -- e.g. room R01
+        # ending up with room R02's ``brick:volume`` literal.
+        consistent_maps = [
+            m
+            for m in candidate_maps
+            if Translator._binding_compatible(m.get(sp_subject), sm_subject)
+        ]
+        if candidate_maps and not consistent_maps:
+            if _diag_walker:
+                _match_diag_write(
+                    f"[WALKER]   PRUNE reason=binding-conflict "
+                    f"pattern={signature_pattern.id} "
+                    f"sp_subject={sp_subject.id} "
+                    f"sm_subject={_diag_sm_name(sm_subject)}"
+                )
+            LOGGER.debug("Pruned (binding conflict)")
+            LOGGER.remove_level()
+            return candidate_maps, feasible, comparison_table, True
+        candidate_maps = consistent_maps
 
         feasible.setdefault(sp_subject, set()).add(sm_subject)
         comparison_table.setdefault(sp_subject, set()).add(sm_subject)
@@ -2960,6 +3008,40 @@ class Translator:
                     sm_neighbors = [
                         x for x in sm_neighbors if not (x in seen or seen.add(x))
                     ]
+
+                    if isinstance(rule, NoStepRule):
+                        # Stand-alone veto: the branch survives iff *no*
+                        # adjacent SM node under the predicate is of the
+                        # forbidden class (an absent predicate trivially
+                        # satisfies the veto).  Nothing is bound.  Before
+                        # this special case the generic "no pair matched /
+                        # missing predicate" pruning below killed every
+                        # branch carrying a stand-alone ``NoStepRule``, so
+                        # the veto only ever worked inside the ``&``
+                        # composite with a positive rule.
+                        far_node = direction.far(rule)
+                        forbidden = [
+                            x for x in sm_neighbors if x.isinstance(far_node.cls)
+                        ]
+                        if forbidden:
+                            feasible[sp_subject].discard(sm_subject)
+                            LOGGER.debug(
+                                "Pruned (NoStepRule veto) [%s]: %s",
+                                direction.name,
+                                Translator._binding_short_name(forbidden[0]),
+                            )
+                            if _diag_walker:
+                                _match_diag_write(
+                                    f"[WALKER]   PRUNE dir={direction.name} "
+                                    f"reason=veto "
+                                    f"pattern={signature_pattern.id} "
+                                    f"sp_subject={sp_subject.id} "
+                                    f"sp_neighbor={sp_neighbor.id} "
+                                    f"sm_subject={_diag_sm_name(sm_subject)}"
+                                )
+                            LOGGER.remove_level()
+                            return candidate_maps, feasible, comparison_table, True
+                        continue
 
                     if sm_neighbors:
                         rule_pairs, _, _, ruleset = rule.apply(
@@ -3082,9 +3164,19 @@ class Translator:
                                 )
                                 for m in maps_for_pair:
                                     m[matched_sp_object] = matched_sm_object
-                                    for sp_n, sm_n in cached.items():
-                                        if m.get(sp_n) is None:
-                                            m[sp_n] = sm_n
+                                    # Cached descendants were derived under
+                                    # the bindings of an earlier branch;
+                                    # only back-fill when they agree with
+                                    # every node this branch has already
+                                    # bound.  Without the check a hub node
+                                    # (e.g. one AHU feeding many rooms)
+                                    # leaks one room's downstream literals
+                                    # (``brick:volume`` value, ...) into
+                                    # the maps of its siblings.
+                                    if Translator._cached_descendants_consistent(m, cached):
+                                        for sp_n, sm_n in cached.items():
+                                            if m.get(sp_n) is None:
+                                                m[sp_n] = sm_n
                                 valid_maps.extend(maps_for_pair)
                                 match_found = True
 
@@ -3398,9 +3490,11 @@ class Translator:
                             )
                             for m in maps_for_pair:
                                 m[matched_sp_object] = matched_sm_object
-                                for sp_n, sm_n in cached.items():
-                                    if m.get(sp_n) is None:
-                                        m[sp_n] = sm_n
+                                # See the matching guard in __prune_recursive.
+                                if Translator._cached_descendants_consistent(m, cached):
+                                    for sp_n, sm_n in cached.items():
+                                        if m.get(sp_n) is None:
+                                            m[sp_n] = sm_n
                             valid_maps.extend(maps_for_pair)
                             match_found = True
 

--- a/twin4build/translator/translator.py
+++ b/twin4build/translator/translator.py
@@ -1812,6 +1812,59 @@ class Translator:
                 LinearConstraint(A_one_input, b_one_input_l, b_one_input_u)
             )
 
+        # 4b. Slot-coherence constraints: a source with candidate edges into
+        # several ports of the same target slot (one damper command feeding
+        # both ``supplyDamperPosition[k]`` and ``exhaustDamperPosition[k]``)
+        # is selected for all of those ports or for none.  Constraint 4
+        # bounds each port on its own, so two candidate sources for one zone
+        # slot could split that zone's ports between them: an equally optimal
+        # solution the solver picks by tie-breaking, and one that wires two
+        # controllers to a single zone.  Per port the edges are summed, so a
+        # port with several candidate edges from the same source is not
+        # forced off by a sibling with one.
+        conn_by_source_slot = {}
+        for e_idx, (
+            source_component,
+            target_component,
+            _,
+            target_key,
+            _,
+            input_port_index,
+        ) in E_idx_to_conn.items():
+            if input_port_index is None:
+                continue
+            by_key = conn_by_source_slot.setdefault(
+                (source_component, target_component, input_port_index), {}
+            )
+            by_key.setdefault(target_key, []).append(e_idx)
+
+        slot_coherence_constraints = []
+        for (_source, _target, slot_idx), by_key in conn_by_source_slot.items():
+            if len(by_key) < 2:
+                continue
+            first_key, *other_keys = list(by_key)
+            for other_key in other_keys:
+                row = np.zeros(total_vars)
+                for e_idx in by_key[first_key]:
+                    row[e_idx] += 1
+                for e_idx in by_key[other_key]:
+                    row[e_idx] -= 1
+                slot_coherence_constraints.append(row)
+                constraint_info.append(
+                    f"sum(E[{first_key}]) - sum(E[{other_key}]) = 0 "
+                    f"(slot {slot_idx} coherence)"
+                )
+
+        if slot_coherence_constraints:
+            A_slot_coherence = np.vstack(slot_coherence_constraints)
+            constraints_list.append(
+                LinearConstraint(
+                    A_slot_coherence,
+                    np.zeros(len(slot_coherence_constraints)),
+                    np.zeros(len(slot_coherence_constraints)),
+                )
+            )
+
         # 5. Modeled-identity mutex constraints.
         #
         # Two kinds of mutual exclusion apply here:

--- a/twin4build/translator/translator.py
+++ b/twin4build/translator/translator.py
@@ -2344,6 +2344,20 @@ class Translator:
         whose ``measuredValue`` input is optional.
         """
         if len(getattr(component, "input", None) or {}) == 0:
+            # A source component with no inputs still needs something to
+            # emit.  A ScheduleSystem the translator instantiated from a
+            # semantic node alone has none of its source flags set and
+            # fails at simulation ("One of use_spreadsheet, use_database,
+            # or use_dict must be True"); before this change such a schedule
+            # was dropped for having no connection, so keeping it now would
+            # turn a translatable model into one that cannot simulate.
+            source_flags = [
+                getattr(component, name)
+                for name in ("use_spreadsheet", "use_database", "use_dict")
+                if hasattr(component, name)
+            ]
+            if source_flags and not any(source_flags):
+                return False
             return True
         return bool(
             getattr(component, "uuid", None)

--- a/twin4build/translator/translator.py
+++ b/twin4build/translator/translator.py
@@ -435,8 +435,14 @@ class Translator:
             # Initialize simulation model
             sim_model = core.SimulationModel(id=model_id)
 
-            # Connect components
-            self._connect_components(result["connections"], sim_model)
+            # Register every MILP-active component and wire the active
+            # connections.  Components must be passed explicitly: a
+            # component with no active connection (a leaf sensor reading a
+            # historian, a stand-alone outdoor environment, ...) is still
+            # part of the solution and must end up in the simulation model.
+            self._connect_components(
+                result["connections"], sim_model, result["components"]
+            )
             LOGGER.remove_level()
             LOGGER.ok("Applying translator", change_status=True)
         else:
@@ -1952,10 +1958,14 @@ class Translator:
 
         # Solve the MILP problem
         if not constraints_list:
-            LOGGER.warning("No valid constraints.")
-            LOGGER.remove_level()
-            LOGGER.warning("Solving MILP problem", change_status=True)
-            return {"success": False, "message": "No valid constraints"}
+            # No connection candidates and no mutual-exclusion constraints
+            # (e.g. a set of Brick leaf sensors translated on their own).
+            # The problem is still well-posed: every component with a
+            # negative net cost is selected.  ``milp`` accepts an empty
+            # constraint list, so fall through instead of failing.
+            LOGGER.warning(
+                "No constraints in MILP problem; selecting components by objective only."
+            )
 
         res = milp(
             c=c, constraints=constraints_list, integrality=integrality, bounds=bounds
@@ -2057,6 +2067,7 @@ class Translator:
                 "message": "Optimization successful",
                 "problem_info": constraint_info,
                 "connections": connections,
+                "components": components,
             }
         LOGGER.warning("Solving MILP problem", change_status=True)
         return {"success": False, "message": res.message}
@@ -2323,10 +2334,28 @@ class Translator:
         LOGGER.remove_level()
         LOGGER.ok("Instantiating components", change_status=True)
 
+    @staticmethod
+    def _is_standalone_component(component: core.System) -> bool:
+        """True if ``component`` can be simulated without any connection.
+
+        Either it declares no input ports at all (outdoor environment,
+        schedules, ...) or it is a data-bound leaf such as a
+        :class:`SensorSystem` with a ``uuid`` / ``filename`` / ``df`` source,
+        whose ``measuredValue`` input is optional.
+        """
+        if len(getattr(component, "input", None) or {}) == 0:
+            return True
+        return bool(
+            getattr(component, "uuid", None)
+            or getattr(component, "filename", None)
+            or getattr(component, "df", None) is not None
+        )
+
     def _connect_components(
         self,
         connections: List[Tuple[core.System, core.System, str, str]],
         sim_model: core.SimulationModel,
+        active_components: Optional[List[core.System]] = None,
     ) -> None:
         """
         Connect instantiated components and add them to simulation model
@@ -2337,9 +2366,40 @@ class Translator:
         """
         LOGGER.task("Connecting components")
         LOGGER.add_level()
+        # Components taking part in an active connection are always kept.
+        # A MILP-active component *without* any connection is kept only if
+        # it can be simulated on its own (see ``_is_standalone_component``):
+        # a Brick leaf sensor bound to a timeseries id, a stand-alone
+        # OutdoorEnvironmentSystem, a schedule.  Previously the used set was
+        # derived from the connection endpoints only, so a solution made of
+        # such components (e.g. a sensor-only translation) produced a Model
+        # with zero components and empty sim2sem / sem2sim maps.  Matched
+        # components whose inputs can never be wired (a virtual sensor with
+        # neither data nor an upstream, a damper nothing feeds) are still
+        # dropped, as before.
+        used_components = set()
+        for conn in connections:
+            used_components.add(conn[0])
+            used_components.add(conn[1])
+        dropped = []
+        for component in active_components or ():
+            if component in used_components:
+                continue
+            if Translator._is_standalone_component(component):
+                used_components.add(component)
+            else:
+                dropped.append(component)
+        if dropped:
+            LOGGER.info(
+                "Dropping %d matched component(s) with unwired inputs and no data source: %s",
+                len(dropped),
+                ", ".join(sorted(c.id for c in dropped)),
+            )
+        for component in sorted(used_components, key=lambda c: c.id):
+            sim_model.add_component(component)
+
         # Extract the components that are actually used in connections
         new_E_conn_to_sp_group = {}
-        used_components = set()
         for conn in connections:
             (
                 source,
@@ -2357,9 +2417,15 @@ class Translator:
             # sim_model.add_connection(*conn) # NOTE: we need to update output_port_index and input_port_index first below
         self.E_conn_to_sp_group = new_E_conn_to_sp_group
 
-        ### JUST ADDED ###
-        # Find which signature patterns are actually used for this component
+        # Find which signature patterns are actually used for each
+        # component.  Connected components keep only the pattern groups
+        # their active connections were derived from; components without
+        # any connection keep the groups recorded at instantiation.
         new_sim2group_map = {}
+        connected_components = {c for conn in connections for c in conn[:2]}
+        for component in used_components - connected_components:
+            if component in self._sim2group_map:
+                new_sim2group_map[component] = self._sim2group_map[component]
         for conn in connections:
             (
                 source,


### PR DESCRIPTION
Brings the whole translator stack to dev as one branch.

## Why this PR exists

The stack was merged bottom-up: `#149` merged `fix/bnode-semantic-instance-init` into dev at 08:06, and the child PRs landed on their parent branches afterwards (`#152` 08:53, `#160` 08:59, `#161` 09:02, `#162` 09:05, `#170` 09:32). Each parent's route to dev had already closed by then, and each level was merged into its own parent before its child arrived, so every branch in the chain ended up holding content its parent never received. This branch merges `fix/bnode-semantic-instance-init` back in, which makes it a superset of the entire stack.

## What it carries

| Issue | PR | Fix |
|---|---|---|
| #145 | #152 | Keep MILP-active components that have no connection, so a sensor-only translation is not empty. An input-free component is kept only when it has a data source, so the example's consumer-less cooling-setpoint schedule stays dropped rather than producing a model that cannot simulate. |
| #155 | #160 | Stand-alone `NoStepRule` veto, and bindings no longer leak between sibling matches through a shared hub node. |
| #157 | #161 | Per-feed transformation dispatch, so `set_transformations` reaches the `OutdoorEnvironmentSystem` irradiation feed as well as the temperature feed. |
| #148 | #162 | Brick 1.4 / BMS-derived graph patterns: `rec:Room` / `rec:Zone` locations, VAVs whose damper command is a direct point, room-attached zone sensors, a room-attached PI-CITS pattern, and the vendored Brick `ref` schema so it parses offline. Includes a MILP slot-coherence constraint: a source feeds every port of a zone slot or none of them, which removes a platform-dependent tie-break that wired two controllers to one zone. |
| #169 | #170 | Model a room radiator from a `brick:Heating_Command` when the graph has no space-heater equipment. |

Closes #145, closes #148, closes #155, closes #157, closes #169.

## Conflict resolution against dev

One conflict in `twin4build/translator/translator.py`: both sides added a different static method at the same insertion point, `_is_standalone_component` from #152 here and `COMPOSITE_ID_NAME_BUDGET` / `_composite_component_id` from #150 on dev. Both are kept; the composite-id call site uses dev's helper and the inline form is gone.

262 translator and model tests pass locally on the merged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
