### PR TITLE
fix: make PI-CITS gains estimable and report the rewire's bounds (#165)

### DIFF
--- a/twin4build/systems/controller/controller_identification/controller_identification_pi_system.py
+++ b/twin4build/systems/controller/controller_identification/controller_identification_pi_system.py
@@ -93,12 +93,19 @@ class ControllerIdentificationPISystem(ControllerIdentificationSystem):
         )
 
     def _build_components(self) -> None:
-        """Build candidates and freeze ``Td = 0`` on every PI candidate.
+        """Build candidates, freeze ``Td = 0`` and mark ``kp`` / ``Ti`` estimable.
 
         The base class already constructs the candidate with ``Td = 0`` from
         ``_candidate_entries[*][1]``, but we also flip ``requires_grad`` off
         defensively so callers that wire ``Td`` into their estimable-parameter
         list cannot accidentally re-introduce a derivative term.
+
+        ``kp`` and ``Ti`` are switched *on*: :class:`PIDControllerSystem`
+        creates them with ``requires_grad=False`` and
+        :meth:`ControllerIdentificationSystem.get_estimable_parameters` skips
+        frozen parameters, so without this ``Estimator.estimate(parameters=
+        "auto")`` silently fitted only the gate parameters and left the
+        gains at their rewire seeds.
         """
         super()._build_components()
         for a in range(self.n_actuators):
@@ -109,6 +116,10 @@ class ControllerIdentificationPISystem(ControllerIdentificationSystem):
                         torch.tensor(0.0, dtype=torch.float64), normalized=False
                     )
                     cand.Td.requires_grad = False
+                for attr in ("kp", "Ti"):
+                    p = getattr(cand, attr, None)
+                    if p is not None and hasattr(p, "requires_grad"):
+                        p.requires_grad = True
 
 
 # ---------------------------------------------------------------------------

--- a/twin4build/systems/controller/controller_identification/controller_identification_system.py
+++ b/twin4build/systems/controller/controller_identification/controller_identification_system.py
@@ -605,13 +605,25 @@ class ControllerIdentificationSystem(core.System, nn.Module):
                         # Skip parameters that the candidate has frozen
                         # (e.g. ``Td`` on the PI subclass).
                         continue
+                    # Prefer the bounds carried by the parameter itself: the
+                    # data-driven rewire (``pi_loop_rewire._set_param``)
+                    # writes per-loop ``(x0, lb, ub)`` onto ``kp`` / ``Ti``
+                    # (Ti up to its 7200 s ceiling), and the static class
+                    # constants (Ti <= 1800 s) would reject those seeds with
+                    # "x0 must be <= upper bound".
+                    lb, ub = bounds
+                    try:
+                        lb = float(p.min_value.min().item())
+                        ub = float(p.max_value.max().item())
+                    except (AttributeError, RuntimeError, ValueError):
+                        pass
                     params.append(
                         (
                             self,
                             f"candidate_{a}_{c}.{attr}",
                             _scalar(p),
-                            bounds[0],
-                            bounds[1],
+                            lb,
+                            ub,
                         )
                     )
 

--- a/twin4build/tests/systems/controller/controller_identification/test_cits_initialize.py
+++ b/twin4build/tests/systems/controller/controller_identification/test_cits_initialize.py
@@ -31,6 +31,45 @@ class TestCitsInitialize(unittest.TestCase):
         self.assertEqual(cits.input["sensorValue"].n_v, 1)
         self.assertEqual(cits.output["inputSignal"].n_v, 1)
 
+    def test_pi_gains_are_estimable(self):
+        """``parameters="auto"`` must see kp / Ti of every PI candidate
+        (regression: they were created frozen and silently skipped, so only
+        the gate parameters were fitted)."""
+        tz = ZoneInfo("Europe/Copenhagen")
+        cits = ControllerIdentificationPISystem(
+            n_sensors=1, n_setpoints=1, n_actuators=1, n_on_off_signals=1, id="cits"
+        )
+        start = datetime.datetime(2024, 3, 4, tzinfo=tz)
+        end = datetime.datetime(2024, 3, 5, tzinfo=tz)
+        cits.initialize(start_time=[start], end_time=[end], step_size=[600])
+        names = [t[1] for t in cits.get_estimable_parameters()]
+        self.assertIn("candidate_0_0.kp", names)
+        self.assertIn("candidate_0_0.Ti", names)
+        self.assertNotIn("candidate_0_0.Td", names)
+
+    def test_estimable_bounds_follow_the_parameter(self):
+        """Bounds written onto ``kp`` / ``Ti`` by the rewire seeding must be
+        what the estimator sees (regression: the class constants were
+        returned, so a rewired Ti = 7200 s > 1800 s was rejected as x0 > ub)."""
+        import torch
+
+        tz = ZoneInfo("Europe/Copenhagen")
+        cits = ControllerIdentificationPISystem(
+            n_sensors=1, n_setpoints=1, n_actuators=1, n_on_off_signals=1, id="cits"
+        )
+        start = datetime.datetime(2024, 3, 4, tzinfo=tz)
+        end = datetime.datetime(2024, 3, 5, tzinfo=tz)
+        cits.initialize(start_time=[start], end_time=[end], step_size=[600])
+        ti = cits.candidate_0_0.Ti
+        ti.min_value = torch.tensor(600.0, dtype=torch.float64)
+        ti.max_value = torch.tensor(7200.0, dtype=torch.float64)
+        ti.set(torch.tensor(7200.0, dtype=torch.float64), normalized=False)
+        (entry,) = [t for t in cits.get_estimable_parameters() if t[1] == "candidate_0_0.Ti"]
+        _, _, x0, lb, ub = entry
+        self.assertAlmostEqual(x0, 7200.0, places=3)
+        self.assertAlmostEqual(lb, 600.0)
+        self.assertAlmostEqual(ub, 7200.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Carries #166 to dev.

## Why this PR exists

`#158` merged this branch into dev at 08:10, closing its route to dev. `#166` then merged into this branch at 09:33, so its content has been sitting here with no open PR. Same bottom-up stacked-merge race as the translator stack (#175).

## What it carries

`#166` (issue #165): PI-CITS `parameters="auto"` never estimated `kp` / `Ti`, because the rewire creates them frozen, and it reported class bounds instead of the rewire's per-loop bounds. The gains are now estimable and the reported bounds come from the rewire.

Closes #165.

Merges cleanly with dev. 42 controller tests pass locally on the merged tree; the estimator and model suites are running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
