### PR TITLE
fix: correct node labels, expose rankdir, warn on degraded drawing

### DIFF
--- a/twin4build/model/semantic_model/semantic_model.py
+++ b/twin4build/model/semantic_model/semantic_model.py
@@ -85,6 +85,10 @@ def parse_wrapper(graph, source=None, **kwargs):
     graph.parse(source, **kwargs)
 
 
+# Layout directions Graphviz accepts for the ``rankdir`` graph attribute.
+_VALID_RANKDIR = ("TB", "BT", "LR", "RL")
+
+
 def get_short_name(uri: Union[str, URIRef], namespaces: Dict[str, Namespace]):
     for namespace in namespaces.values():
         if namespace in str(uri):
@@ -2492,6 +2496,7 @@ class SemanticModel:
         instance_style=None,
         deduplicate_inverse=True,
         pydot_transform=None,
+        rankdir=None,
     ):
         """
         Visualize RDF graph with optional class and predicate filtering.
@@ -2539,7 +2544,17 @@ class SemanticModel:
                 (e.g. s4syst:connectedThrough / s4syst:connectsSystem).
             pydot_transform: Optional callable that receives the pydotplus graph
                 object after node styling and can modify it in place before rendering.
+            rankdir: Layout direction passed to Graphviz: ``"TB"`` (default
+                when None), ``"BT"``, ``"LR"`` or ``"RL"``. Wide, shallow
+                graphs are usually far more readable with ``"LR"``.
         """
+        # Validated up front: styling a large graph is slow, so an unusable
+        # value should fail before that work rather than after it.
+        if rankdir is not None and rankdir not in _VALID_RANKDIR:
+            raise ValueError(
+                f"rankdir must be one of {_VALID_RANKDIR}, got {rankdir!r}"
+            )
+
         # Omit rdf:type triples by default
         if query is None:
             query = """
@@ -2733,14 +2748,24 @@ class SemanticModel:
                 # Remove any existing width attribute that might conflict
                 if "width" in soup.table.attrs:
                     del soup.table.attrs["width"]
-                soup.table.attrs.update(
-                    {
-                        "BORDER": "2",
-                        "CELLSPACING": "0",
-                        "CELLPADDING": "2",
-                        "CELLBORDER": "0",
-                    }
-                )
+                # rdf2dot emits lowercase ``border``/``cellborder``/
+                # ``cellspacing`` and BeautifulSoup's html.parser keeps
+                # attribute names lowercased, so simply adding the uppercase
+                # spellings below would leave BOTH in the tag (e.g.
+                # ``BORDER="2" ... border="1"``).  Graphviz's HTML-like
+                # parser is case-insensitive and kept the rdf2dot value, so
+                # the intended 2pt border silently rendered at 1pt.  Drop any
+                # existing spelling first.
+                table_attrs = {
+                    "BORDER": "2",
+                    "CELLSPACING": "0",
+                    "CELLPADDING": "2",
+                    "CELLBORDER": "0",
+                }
+                for existing in list(soup.table.attrs):
+                    if existing.upper() in table_attrs:
+                        del soup.table.attrs[existing]
+                soup.table.attrs.update(table_attrs)
                 row = soup.find_all("tr")[1]
                 col = row.find_all("td")[0]
                 uri = col.string
@@ -2891,6 +2916,19 @@ class SemanticModel:
                         else:
                             s = col.get_text()
 
+                        # Row 1 is the instance name.  rdf2dot builds it with
+                        # ``compute_qname(uri)[2]`` and falls back to the FULL
+                        # URI whenever that raises -- which it does for any id
+                        # that is not a valid NCName.  Twin4Build's composite
+                        # component ids contain "[" and "]", so those nodes
+                        # showed the whole URI here, duplicating the URI row
+                        # (and still doing so with include_full_uri=False,
+                        # which only drops row 2).  Derive it from the
+                        # instance instead, which splits on the registered
+                        # namespaces without NCName validation.
+                        if i == 1 and len(cols_in_row) == 1:
+                            s = inst.get_short_name()
+
                         # Replace old cell with a clean new <td> (uppercase attrs)
                         new_col = soup.new_tag("td", attrs=td_attrs)
                         col.replace_with(new_col)
@@ -2902,10 +2940,12 @@ class SemanticModel:
                             s = s_
                         font.append(s)
 
-                # Remove the last row if include_full_uri is False
+                # Remove the full-URI row (row 2) if include_full_uri is False.
+                # The guard has to be > 2, not > 0: indexing [2] on a shorter
+                # table raises IndexError.
                 if not include_full_uri:
                     all_rows = soup.find_all("tr")
-                    if len(all_rows) > 0:
+                    if len(all_rows) > 2:
                         all_rows[2].decompose()
 
                 # Slice the URI string in row 1 if slice_uri is provided
@@ -2955,6 +2995,13 @@ class SemanticModel:
                 node.obj_dict["attributes"]["label"] = (
                     str(soup).replace("&lt;", "<").replace("&gt;", ">")
                 )
+
+        # ``rankdir`` has to be on the graph before layout: the renderer's
+        # final ``neato -n2`` pass only reuses existing positions, so setting
+        # it at render time does nothing.  Applied before ``pydot_transform``
+        # so a caller-supplied transform can still override it.
+        if rankdir is not None:
+            dg.set("rankdir", rankdir)
 
         if pydot_transform is not None:
             pydot_transform(dg)

--- a/twin4build/tests/model/semantic_model/test_semantic_model.py
+++ b/twin4build/tests/model/semantic_model/test_semantic_model.py
@@ -1,10 +1,12 @@
 # Standard library imports
 import os
+import re
 import shutil
 import tempfile
 import unittest
 
 # Third party imports
+from bs4 import BeautifulSoup
 from rdflib import RDF, RDFS, XSD, BNode, Graph, Literal, Namespace, URIRef
 
 # Local application imports
@@ -2211,6 +2213,122 @@ class TestSemanticModel(unittest.TestCase):
 
         self._setup_visualize_data()
         self.model.visualize(dpi=100)
+
+    # ==================== visualize() node label Tests ====================
+
+    def _read_object_graph_dot(self):
+        """Return the styled DOT that visualize() handed to Graphviz."""
+        dot_path, _ = self.model.get_dir(
+            folder_list=["graphs", "temp"], filename="object_graph.dot"
+        )
+        with open(dot_path, encoding="utf-8") as handle:
+            return handle.read()
+
+    @staticmethod
+    def _node_label_rows(dot_text):
+        """Return the row texts of every node's HTML-like table label."""
+        labels = re.findall(r"label=<\s*(<table.*?</table>)\s*>", dot_text, re.S)
+        return [
+            [
+                row.get_text().strip()
+                for row in BeautifulSoup(html, "html.parser").find_all("tr")
+            ]
+            for html in labels
+        ]
+
+    def _setup_composite_id_data(self):
+        """An instance whose local name is not a valid NCName.
+
+        Twin4Build's composite component ids contain "[" and "]", which makes
+        ``rdflib.namespace.split_uri`` raise, so ``rdf2dot`` falls back to
+        emitting the whole URI as the node's name.
+        """
+        example_ns = Namespace("http://example.org/")
+        self.model.add_namespaces({"EX": example_ns})
+        type_uri = URIRef("http://example.org/TestClass")
+        composite = URIRef("http://example.org/[nabc123][R08_06_O_CO202]")
+        self.model.ontology_graph.add(
+            (type_uri, RDF.type, URIRef("http://www.w3.org/2002/07/owl#Class"))
+        )
+        self.model.instance_graph.add((composite, RDF.type, type_uri))
+        self.model.instance_graph.add(
+            (composite, URIRef("http://example.org/hasName"), Literal("composite"))
+        )
+        return str(composite)
+
+    def test_visualize_name_row_not_full_uri_for_composite_id(self):
+        """The name row must not duplicate the full-URI row (regression)."""
+        if not self.graphviz_installed:
+            self.skipTest("Graphviz drawing backend is not available")
+
+        composite_uri = self._setup_composite_id_data()
+        self.model.visualize()
+        rows_per_node = self._node_label_rows(self._read_object_graph_dot())
+        self.assertTrue(rows_per_node, "no node labels found in the styled DOT")
+        for rows in rows_per_node:
+            self.assertGreaterEqual(len(rows), 2)
+            # rows[0] is the type header, rows[1] the instance name.
+            self.assertNotEqual(
+                rows[1],
+                composite_uri,
+                "name row still duplicates the full URI row",
+            )
+            self.assertFalse(
+                rows[1].startswith("http"),
+                f"name row should be a local name, got {rows[1]!r}",
+            )
+
+    def test_visualize_name_row_not_full_uri_without_uri_row(self):
+        """include_full_uri=False must not leave the URI in the name row."""
+        if not self.graphviz_installed:
+            self.skipTest("Graphviz drawing backend is not available")
+
+        self._setup_composite_id_data()
+        self.model.visualize(include_full_uri=False)
+        for rows in self._node_label_rows(self._read_object_graph_dot()):
+            self.assertFalse(
+                rows[1].startswith("http"),
+                f"name row should be a local name, got {rows[1]!r}",
+            )
+
+    def test_visualize_table_border_attribute_not_duplicated(self):
+        """rdf2dot's lowercase border= must not survive next to BORDER=."""
+        if not self.graphviz_installed:
+            self.skipTest("Graphviz drawing backend is not available")
+
+        self._setup_visualize_data()
+        self.model.visualize()
+        for tag in set(re.findall(r"<table[^>]*>", self._read_object_graph_dot())):
+            self.assertIn("BORDER=", tag)
+            self.assertNotRegex(
+                tag,
+                r"\bborder=",
+                f"lowercase border= survives and overrides BORDER=: {tag}",
+            )
+
+    def test_visualize_rankdir_is_applied(self):
+        """rankdir must reach the DOT, where it can affect the layout."""
+        if not self.graphviz_installed:
+            self.skipTest("Graphviz drawing backend is not available")
+
+        self._setup_visualize_data()
+        self.model.visualize(rankdir="LR")
+        self.assertRegex(self._read_object_graph_dot(), r"rankdir\s*=\s*LR")
+
+    def test_visualize_rankdir_defaults_to_unset(self):
+        """Without rankdir the DOT stays as before (Graphviz default TB)."""
+        if not self.graphviz_installed:
+            self.skipTest("Graphviz drawing backend is not available")
+
+        self._setup_visualize_data()
+        self.model.visualize()
+        self.assertNotRegex(self._read_object_graph_dot(), r"rankdir\s*=")
+
+    def test_visualize_rankdir_rejects_invalid_value(self):
+        """An unusable rankdir should fail loudly rather than be ignored."""
+        self._setup_visualize_data()
+        with self.assertRaises(ValueError):
+            self.model.visualize(rankdir="sideways")
 
 
 if __name__ == "__main__":

--- a/twin4build/utils/graphviz_render.py
+++ b/twin4build/utils/graphviz_render.py
@@ -5,7 +5,7 @@ Twin4Build historically laid out semantic-model drawings with this pipeline::
     ccomps -x                  # split weakly connected components
     dot                        # hierarchical layout of each component
     gvpack -array3             # pack components into a 3-column array
-    neato -n2 -Gsize=10! -Gdpi={dpi} -Grankdir=RL
+    neato -n2 -Gsize=10! -Gdpi={dpi}
 
 ``pygraphviz`` 2.0 wheels bundle the Graphviz libraries and layout plugins
 but not the ``dot``, ``neato``, or ``gvpack`` executables. Layout is done
@@ -32,9 +32,27 @@ from twin4build.utils.logger import LOGGER
 
 _SYSTEM_TOOLS = ("ccomps", "dot", "gvpack", "neato")
 
-# Render-time flags historically passed to ``neato -n2``.
-_PACKED_DRAW_ARGS = "-Gsize=10! -Grankdir=RL"
+# Render-time flags passed to ``neato -n2``.
+#
+# ``rankdir`` is deliberately *not* here.  It only affects a hierarchical
+# layout, and by this point the layout is already done -- ``neato -n2`` reuses
+# the existing node positions.  The historical pipeline passed ``-Grankdir=RL``
+# at this stage, where it was silently inert.  Set ``rankdir`` on the graph
+# before layout instead (``SemanticModel.visualize(rankdir=...)``).
+_PACKED_DRAW_ARGS = "-Gsize=10!"
 _PACK_MODE = "array_3"
+
+# The system pipeline measures text with whatever metrics its Graphviz build
+# has.  Builds without a real text-layout plugin (no pango/fontconfig) fall
+# back to Times metrics while still emitting ``font-family="Courier,..."``,
+# so every node box is sized ~20% too narrow and labels are clipped.  The
+# pygraphviz wheel bundles working text layout, so prefer it.
+SYSTEM_BACKEND_HINT = (
+    "Rendering with system Graphviz because pygraphviz is not installed. "
+    "Graphviz builds without a text-layout plugin size node boxes with Times "
+    "metrics while labelling them Courier, which clips label text. Install "
+    "'pygraphviz>=2.0.1' for correctly sized nodes."
+)
 
 DRAWING_UNAVAILABLE_HINT = (
     "Graphviz drawing is unavailable. It is provided by the pygraphviz "
@@ -143,6 +161,11 @@ def render_dot_graph(
                 "pygraphviz drawing failed (%s); falling back to system Graphviz.",
                 exc,
             )
+    else:
+        # backend == "system": pygraphviz is not installed at all.  Say so,
+        # because the output is silently degraded rather than merely slower.
+        warnings.warn(SYSTEM_BACKEND_HINT, RuntimeWarning, stacklevel=2)
+        LOGGER.warning(SYSTEM_BACKEND_HINT)
 
     _render_with_system_tools(
         dot_filename=dot_filename,
@@ -276,7 +299,7 @@ def _render_with_pygraphviz(
     if "packmode" in graph.graph_attr:
         del graph.graph_attr["packmode"]
 
-    # neato -n2 -Gsize=10! -Gdpi={dpi} -Grankdir=RL
+    # neato -n2 -Gsize=10! -Gdpi={dpi}
     draw_args = f"{_PACKED_DRAW_ARGS} -Gdpi={dpi}"
     graph.draw(output_path, format=format, args=draw_args)
 
@@ -356,7 +379,6 @@ def _render_with_system_tools(
             "-n2",
             "-Gsize=10!",
             f"-Gdpi={dpi}",
-            "-Grankdir=RL",
             "-q",
             f"-o{output_path}",
             packed_dot,


### PR DESCRIPTION
Fixes #180, fixes #181, fixes #182, fixes #183.

Four defects in the semantic-model drawing path, all surfaced by comparing `visualize()` output against a hand-written DOT of the same model.

## 1. Name row duplicated the full URI (#180)

`rdf2dot` builds the name row from `compute_qname(uri)[2]` and falls back to returning the **whole URI** on any exception. Twin4Build's composite component ids contain `[` and `]`, which are not valid NCName characters, so `split_uri` raises:

    ValueError: Can't split 'http://twin4build.org/[nabc123][R08_06_O_CO202]'

**33 of 101 nodes** in a translated HTR model showed the full URI in both the name row and the URI row. `include_full_uri=False` did not help, because it only drops row 2 — so for exactly these nodes the option looked broken.

Now derived from the instance (`inst.get_short_name()`), which splits on registered namespaces without NCName validation. The removal guard was also wrong: `len(all_rows) > 0` while indexing `[2]`.

## 2. Table `BORDER="2"` never applied (#181)

BeautifulSoup's `html.parser` keeps attribute names lowercased, so adding the uppercase spellings left **both** in the tag:

```
<table BORDER="2" ... border="1" cellborder="0" cellspacing="0">
```

Graphviz is case-insensitive and kept rdf2dot's value, so the border rendered at 1pt. The output SVG had no `stroke-width` attribute at all; it now emits `stroke-width="2"`.

## 3. `rankdir` unreachable, `-Grankdir=RL` dead code (#182)

The flag was passed to the final `neato -n2` stage, which reuses existing positions and does not re-layout — so it never had any effect, in either the historical pipeline or its port. `rankdir` only matters to the `dot` stage.

Added `visualize(rankdir=...)`, validated up front and set on the graph before layout; dropped the inert flag from both render paths. Same styled DOT:

| rankdir | canvas | aspect |
|---|---|---|
| TB (default, unchanged) | 3000x363pt | 8.3 : 1 |
| LR | 3000x2091pt | 1.4 : 1 |

## 4. Silent fallback clipped every label (#183)

Graphviz builds without a text-layout plugin measure text with Times metrics while labelling it Courier. Same DOT, same label at 14pt:

| backend | cell width | implied advance | declares |
|---|---|---|---|
| system pipeline (no pango) | 220.0pt | 0.491 em | `Courier,monospace` |
| pygraphviz wheel | 268.0pt | 0.598 em | `Courier,monospace` |

Courier's real advance is 0.600 em, so the system path sizes every box ~20% too narrow. Only SVG shows it — PNG is drawn with the same wrong metrics it measured with. The fallback now warns, since it degrades output rather than merely being slower.

## Tests

Six regression tests added. **Five of the six fail on `dev`** and pass here; the sixth asserts the unchanged default (no `rankdir` in the DOT), so it passes on both by design.

```
162 passed   test_semantic_model.py + test_graphviz_render.py
```

`flake8 --select=E9,F63,F7,F82` clean. `graphviz_render.py` was already non-black-clean on `dev`, so it is left as-is rather than adding unrelated reformatting churn.

## Compatibility

No behaviour change without the new kwarg: `rankdir` defaults to `None` and is appended last in the signature. Node labels change only where they were previously showing a duplicated URI, and borders now render at the 2pt the code always asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)