### PR TITLE
feat: CUDA torch install extra (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ API-quality major release. Preferred forms are documented below; new soft-compat
 - `get_component_by_class(dict_, ...)` → `get_components_by_class(Cls)`
 - `twin4build.utils.print_progress` → `twin4build.utils.logger`
 
+### Added
+
+- `[gpu]` extra and a documented CUDA torch install. `pip install twin4build`
+  still follows PyPI's default `torch` wheel (CPU-only on Windows).
+  `pip install twin4build[gpu] --extra-index-url https://download.pytorch.org/whl/cu128`
+  pulls a CUDA 12.8+ build and Triton on Linux. Compiled / CUDA-graph paths
+  need Linux or WSL (Triton has no Windows wheels). `model.to("cuda")`
+  raises with that install line when the process has no CUDA (issue #167).
+
 ### Changed
 
 - New batched shooting solver method `("custom", "batched-tr", "ad")`: a

--- a/README.md
+++ b/README.md
@@ -179,8 +179,37 @@ Optional extras:
 
 ```bat
 pip install twin4build[database]     # PostgreSQL connectivity
-pip install twin4build[all]          # Everything
+pip install twin4build[gpu] --extra-index-url https://download.pytorch.org/whl/cu128
+pip install twin4build[all]          # Dev + database (not CUDA torch)
 ```
+
+### GPU / CUDA installation
+
+`pip install twin4build` installs whatever `torch` wheel PyPI serves for the
+platform. On Windows that is the **CPU-only** build, so
+`torch.cuda.is_available()` is False even on a machine with a supported GPU,
+and GPU execution modes run on CPU or fail with an opaque torch error.
+
+Install a CUDA 12.8+ build (Blackwell needs cu128 or newer):
+
+```bat
+pip install twin4build[gpu] --extra-index-url https://download.pytorch.org/whl/cu128
+```
+
+If CPU torch is already installed, reinstall it from that index:
+
+```bat
+pip install torch --index-url https://download.pytorch.org/whl/cu128
+pip install twin4build[gpu]
+```
+
+`[gpu]` pulls Triton on Linux. Triton ships no Windows wheels, so the compiled
+step (`compile_step`) and CUDA-graph paths need **Linux or WSL** — native
+Windows can use CUDA eager execution after the CUDA torch install, but not
+Inductor/Triton.
+
+`model.to("cuda")` now raises with this install line when the process has no
+CUDA, instead of torch's "not compiled with CUDA enabled".
 
 The following python versions are supported (Twin4Build 2.0 requires Python 3.10+; 3.9 is no longer supported):
 

--- a/docs/source/manual/developer_reference.rst
+++ b/docs/source/manual/developer_reference.rst
@@ -114,7 +114,9 @@ If you prefer to set up manually or need a different environment manager:
     conda activate t4bdev
 
     # Install in development mode with dependencies
-    pip install -e .[dev]
+    pip install -e ".[dev]"
+    # CUDA torch (optional; PyPI's default wheel is CPU-only on Windows):
+    pip install -e ".[dev,gpu]" --extra-index-url https://download.pytorch.org/whl/cu128
 
 **Alternative environment managers**: You can also use venv, virtualenv, poetry, or pipenv - just ensure you have an isolated Python 3.10+ environment.
 
@@ -207,6 +209,7 @@ Git Workflow
    conda create -n t4bdev python=3.12
    conda activate t4bdev
    python -m pip install -e ".[dev]"
+   # GPU (optional): python -m pip install -e ".[dev,gpu]" --extra-index-url https://download.pytorch.org/whl/cu128
 
 With ``venv``, replace the first two commands with the platform-appropriate
 environment creation and activation commands. Keep the editable install so

--- a/docs/source/manual/installation.rst
+++ b/docs/source/manual/installation.rst
@@ -25,7 +25,10 @@ For additional functionality, you can install optional dependencies:
     # For database connectivity
     pip install twin4build[database]
 
-    # For all optional dependencies
+    # CUDA torch (PyPI's default wheel is CPU-only on Windows)
+    pip install twin4build[gpu] --extra-index-url https://download.pytorch.org/whl/cu128
+
+    # For all optional dependencies (dev + database; not CUDA torch)
     pip install twin4build[all]
 
 For Developers
@@ -107,8 +110,41 @@ Core dependencies (automatically installed):
 Optional dependencies:
 
 - ``[database]``: psycopg2-binary, sqlalchemy
+- ``[gpu]``: Triton on Linux. CUDA torch itself is not on PyPI; pass
+  ``--extra-index-url https://download.pytorch.org/whl/cu128`` (or install
+  ``torch`` from that index first). See :ref:`gpu-cuda-installation`.
 - ``[dev]``: coverage, black, flake8, isort, sphinx, sphinx-rtd-theme, sphinx-autodoc-typehints, myst-parser, twine
-- ``[all]``: everything above
+- ``[all]``: ``[dev]`` + ``[database]`` (not CUDA torch)
+
+.. _gpu-cuda-installation:
+
+GPU / CUDA installation
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``pip install twin4build`` follows PyPI's default ``torch`` wheel. On Windows
+that is the CPU-only build, so ``torch.cuda.is_available()`` is False even
+when the machine has a supported GPU.
+
+Install a CUDA 12.8+ build (Blackwell needs cu128 or newer):
+
+.. code-block:: bash
+
+    pip install twin4build[gpu] --extra-index-url https://download.pytorch.org/whl/cu128
+
+If CPU torch is already installed, reinstall it from that index:
+
+.. code-block:: bash
+
+    pip install torch --index-url https://download.pytorch.org/whl/cu128
+    pip install twin4build[gpu]
+
+Compiled / CUDA-graph paths (``compile_step``,
+``execution_backend="cuda_graph"``) need **Linux or WSL** because Triton
+ships no Windows wheels. Native Windows can use CUDA eager execution after
+the CUDA torch install.
+
+``model.to("cuda")`` raises with this install line when the process has no
+CUDA.
 
 Verifying Installation
 ----------------------
@@ -131,6 +167,12 @@ Troubleshooting
 
 Common Issues
 ~~~~~~~~~~~~~
+
+**``torch.cuda.is_available()`` is False / Torch not compiled with CUDA**
+
+- Default ``pip install twin4build`` on Windows is CPU-only. Install CUDA
+  torch as in :ref:`gpu-cuda-installation`.
+- Compiled / CUDA-graph paths need Linux or WSL (no Triton wheels on Windows).
 
 **Import Error: No module named 'twin4build'**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# CUDA torch is not on PyPI: the default ``torch`` dependency is whatever
+# wheel PyPI serves (CPU-only on Windows). Install a CUDA 12.8+ build with
+#   pip install twin4build[gpu] --extra-index-url https://download.pytorch.org/whl/cu128
+# or install torch from that index first. Triton has no Windows wheels, so
+# compiled / CUDA-graph paths need Linux or WSL (issue #167).
+gpu = [
+    "triton; platform_system == 'Linux'",
+]
 dev = [
     "coverage",
     "black",
@@ -95,7 +103,7 @@ dev = [
     "pytest-cov",
     "pytest-html",
     "build",
-    "twine"
+    "twine",
 ]
 database = [
     "psycopg2-binary",

--- a/twin4build/model/simulation_model/simulation_model.py
+++ b/twin4build/model/simulation_model/simulation_model.py
@@ -43,7 +43,7 @@ from twin4build.systems.controller.controller_identification.pi_loop_rewire impo
 )
 from twin4build.systems.utils.fused_statespace_system import FusedStateSpaceSystem
 from twin4build.utils.deprecation import deprecate_name
-from twin4build.utils.device import move_object_tensors
+from twin4build.utils.device import ensure_cuda_available, move_object_tensors
 
 INVALID_ID_CHARS = ["_", "-", " ", "(", ")", "[", "]"]
 
@@ -437,6 +437,7 @@ class SimulationModel:
         """
 
         if device is not None:
+            ensure_cuda_available(device)
             self._device = torch.device(device)
         if dtype is not None:
             tps.set_float_dtype(dtype)

--- a/twin4build/tests/simulator/test_device.py
+++ b/twin4build/tests/simulator/test_device.py
@@ -20,6 +20,7 @@ CUDA parity (auto-skipped without a GPU):
 # Standard library imports
 import datetime
 import unittest
+from unittest import mock
 
 # Third party imports
 import numpy as np
@@ -164,6 +165,38 @@ class TestModelToCUDA(unittest.TestCase):
             "functional single-shooting objective was not built on CUDA",
         )
         self.assertTrue(np.all(np.isfinite(result["result_x"])))
+
+
+class TestEnsureCudaAvailable(unittest.TestCase):
+    """``model.to("cuda")`` must name the CUDA install, not fail opaquely."""
+
+    def test_cpu_is_noop(self):
+        from twin4build.utils.device import ensure_cuda_available
+
+        ensure_cuda_available(None)
+        ensure_cuda_available("cpu")
+
+    def test_cpu_wheel_names_the_install_line(self):
+        from twin4build.utils.device import CUDA_INSTALL_HINT, ensure_cuda_available
+
+        with (
+            mock.patch("torch.cuda.is_available", return_value=False),
+            mock.patch("torch.backends.cuda.is_built", return_value=False),
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                ensure_cuda_available("cuda")
+        self.assertIn(CUDA_INSTALL_HINT, str(ctx.exception))
+        self.assertIn("WSL", str(ctx.exception))
+
+    def test_cuda_build_without_a_device(self):
+        from twin4build.utils.device import ensure_cuda_available
+
+        with (
+            mock.patch("torch.cuda.is_available", return_value=False),
+            mock.patch("torch.backends.cuda.is_built", return_value=True),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "no GPU is visible"):
+                ensure_cuda_available("cuda")
 
 
 if __name__ == "__main__":

--- a/twin4build/utils/device.py
+++ b/twin4build/utils/device.py
@@ -21,6 +21,40 @@ from typing import Optional
 import torch
 import torch.nn as nn
 
+# CUDA wheels live on PyTorch's index, not PyPI (issue #167).
+CUDA_TORCH_INDEX = "https://download.pytorch.org/whl/cu128"
+CUDA_INSTALL_HINT = f"pip install twin4build[gpu] --extra-index-url {CUDA_TORCH_INDEX}"
+
+
+def ensure_cuda_available(device) -> None:
+    """Raise if ``device`` is CUDA but this process cannot use a GPU.
+
+    ``pip install twin4build`` follows PyPI's default torch wheel, which on
+    Windows is CPU-only, so ``model.to("cuda")`` would otherwise fail with
+    torch's ``Torch not compiled with CUDA enabled``.  Say that once, with
+    the install line, instead of looking like a silent CPU fallback.
+    """
+    if device is None:
+        return
+    if torch.device(device).type != "cuda":
+        return
+    if torch.cuda.is_available():
+        return
+    if torch.backends.cuda.is_built():
+        raise RuntimeError(
+            "CUDA was requested but no GPU is visible to this process "
+            "(torch.cuda.is_available() is False). Check the NVIDIA driver. "
+            f"GPU Twin4Build install: {CUDA_INSTALL_HINT}"
+        )
+    raise RuntimeError(
+        "CUDA was requested but this torch build has no CUDA "
+        "(the default PyPI wheel on Windows is CPU-only). Install a "
+        f"CUDA 12.8+ build with:\n  {CUDA_INSTALL_HINT}\n"
+        "Compiled / CUDA-graph paths also need Linux or WSL because "
+        "Triton ships no Windows wheels. See the README GPU / CUDA "
+        "installation section."
+    )
+
 
 def _move_tensor(
     t: torch.Tensor, device: torch.device, dtype: Optional[torch.dtype]
@@ -75,9 +109,7 @@ def _assign(container, key, value) -> None:
         setattr(container, key, value)
 
 
-def move_object_tensors(
-    root, device, dtype: Optional[torch.dtype] = None
-) -> None:
+def move_object_tensors(root, device, dtype: Optional[torch.dtype] = None) -> None:
     """Recursively move every tensor reachable from ``root`` to ``device``.
 
     Traverses attributes of twin4build objects and ``nn.Module``s plus plain
@@ -135,9 +167,11 @@ def move_object_tensors(
                             container,
                             key,
                             tuple(
-                                _move_tensor(v, device, dtype)
-                                if isinstance(v, torch.Tensor)
-                                else v
+                                (
+                                    _move_tensor(v, device, dtype)
+                                    if isinstance(v, torch.Tensor)
+                                    else v
+                                )
                                 for v in value
                             ),
                         )


### PR DESCRIPTION
## Summary
- Add a `[gpu]` extra that pulls Triton on Linux, and document the CUDA 12.8+ install: `pip install twin4build[gpu] --extra-index-url https://download.pytorch.org/whl/cu128`.
- README, installation guide, and developer reference now say that PyPI's default torch wheel is CPU-only on Windows, that compiled / CUDA-graph paths need Linux or WSL (no Triton wheels), and that Blackwell needs cu128+.
- `model.to(cuda)` raises with that install line when the process has no CUDA, instead of torch's opaque `not compiled with CUDA enabled`.

Closes #167.

## Test plan
- [x] `TestEnsureCudaAvailable` (CPU no-op, CPU-wheel error names the extra-index-url, CUDA-build-without-device names the driver)
- [ ] `pip install twin4build[gpu] --extra-index-url https://download.pytorch.org/whl/cu128` on a CUDA machine yields `torch.cuda.is_available()`
- [ ] Native Windows still documents WSL for `compile_step` / CUDA graphs

Made with [Cursor](https://cursor.com)