### PR TITLE
fix: Model.serialize()/load(filename) round-trips parameters and sensor transformations (#190)

### DIFF
--- a/twin4build/model/simulation_model/simulation_model.py
+++ b/twin4build/model/simulation_model/simulation_model.py
@@ -3752,6 +3752,31 @@ class SimulationModel:
                 class_name,
             )
             component = cls(id=sm_instance.get_short_name(), **attributes)
+            # The literals are the flattened ``populate_config()`` of the
+            # serialized component, so a nested parameter arrives as a
+            # dotted key (``mass.V``, ``supply_damper.a``) that no
+            # constructor takes, and a class may not expose every parameter
+            # as a constructor argument.  Constructors only see the
+            # keyword-shaped literals; every literal that resolves to a
+            # ``tps.Parameter`` on the built component is written to it here,
+            # so a serialized model reloads with its (fitted) values.
+            for key, value in attributes.items():
+                if value is None or not rhasattr(component, key):
+                    continue
+                if isinstance(rgetattr(component, key), (tps.Parameter, tps.TensorParameter)):
+                    # A per-branch (n_c > 1) literal replaces the freshly
+                    # built scalar parameter with one of that width -- the
+                    # owner's initialize then finds it already expanded.
+                    per_branch = isinstance(value, list) and len(value) > 1
+                    try:
+                        self.set_parameters(
+                            [value], [component], [key], overwrite=per_branch
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        raise RuntimeError(
+                            f"cannot restore parameter {key}={value!r} on "
+                            f"{class_name} '{component.id}' from {rdf_file}: {exc}"
+                        ) from exc
             # Check if the component already exists
             self.add_component(component)
         LOGGER.remove_level()

--- a/twin4build/systems/saref4syst/system.py
+++ b/twin4build/systems/saref4syst/system.py
@@ -11,6 +11,7 @@ import torch
 from prettytable import PrettyTable
 
 # Local application imports
+import twin4build.utils.types as tps
 from twin4build.utils.rgetattr import rgetattr
 from twin4build.utils.rhasattr import rhasattr
 from twin4build.utils.simulation_time import get_simulation_timesteps
@@ -534,7 +535,14 @@ class System:
         """
 
         def extract_value(value):
-            if hasattr(value, "detach") and hasattr(value, "numpy"):
+            # ``tps.Parameter`` (an nn.Parameter) and ``tps.TensorParameter``
+            # (what ``set_parameters(overwrite=True)`` -- the estimator's
+            # write path -- leaves behind) both publish their physical value
+            # through ``get()``; serializing anything else would write the
+            # object's repr into the graph.
+            if isinstance(value, (tps.Parameter, tps.TensorParameter)) or (
+                hasattr(value, "get") and hasattr(value, "detach")
+            ):
                 # Use .tolist() to convert numpy types to Python native types
                 # This ensures values like np.float64(1.0) become 1.0
                 return value.get().detach().cpu().numpy().flatten().tolist()

--- a/twin4build/systems/sensor/sensor_system.py
+++ b/twin4build/systems/sensor/sensor_system.py
@@ -1,5 +1,7 @@
 # Standard library imports
 import datetime
+import warnings
+import importlib
 from typing import Any, Callable, Dict, List, Optional, Union
 
 # Third party imports
@@ -1147,6 +1149,7 @@ class SensorSystem(core.System):
         use_database: bool = False,
         use_df: bool = False,
         transformation: Optional[callable] = None,
+        transformation_ref: Optional[str] = None,
         **kwargs,
     ) -> None:
         """Initialize the sensor system.
@@ -1232,9 +1235,12 @@ class SensorSystem(core.System):
         self._is_leaf = None
         self._time_series_input = None
         self._transformation = transformation
+        if transformation is None and transformation_ref:
+            # A serialized model carries the transformation by import path.
+            self.transformation_ref = transformation_ref
 
         self._config = {
-            "parameters": ["use_spreadsheet", "use_database", "use_df"],
+            "parameters": ["use_spreadsheet", "use_database", "use_df", "transformation_ref"],
             "spreadsheet": ["filename", "datecolumn", "valuecolumn"],
             "database": ["uuid", "dbconfig"],
         }
@@ -1459,6 +1465,37 @@ class SensorSystem(core.System):
     @transformation.setter
     def transformation(self, fn: Optional[Callable]) -> None:
         self._transformation = fn
+
+    @property
+    def transformation_ref(self) -> Optional[str]:
+        """The transformation as an import path ``module:qualname`` -- the
+        form that survives ``Model.serialize()`` / ``Model.load(filename=...)``
+        (a callable is not a literal).  ``None`` when there is no
+        transformation, or when it cannot be named (a lambda or a closure):
+        such a model reloads without it, with a warning at serialize time."""
+        fn = self._transformation
+        if fn is None:
+            return None
+        qualname = getattr(fn, "__qualname__", "")
+        if not qualname or "<" in qualname or fn.__module__ is None:
+            warnings.warn(
+                f"|CLASS: {self.__class__.__name__}|ID: {self.id}|: the transformation "
+                f"{fn!r} is not importable by name and will not survive serialization; "
+                "use a module-level function.",
+                stacklevel=2,
+            )
+            return None
+        return f"{fn.__module__}:{qualname}"
+
+    @transformation_ref.setter
+    def transformation_ref(self, ref: Optional[str]) -> None:
+        if not ref:
+            return
+        module_name, _, qualname = ref.partition(":")
+        obj = importlib.import_module(module_name)
+        for part in qualname.split("."):
+            obj = getattr(obj, part)
+        self._transformation = obj
 
     def set_transformation(self, fn: Optional[Callable]) -> None:
         """Set the unit-conversion callable applied to loaded timeseries.

--- a/twin4build/systems/space_heater/space_heater_system.py
+++ b/twin4build/systems/space_heater/space_heater_system.py
@@ -256,6 +256,7 @@ class SpaceHeaterSystem(core.System, nn.Module):
         thermalMassHeatCapacity: float = 500000,
         nelements: int = 3,
         initialize_UA: bool = True,
+        UA: Optional[float] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -265,9 +266,13 @@ class SpaceHeaterSystem(core.System, nn.Module):
         self.T_b_nominal_sh = T_b_nominal_sh
         self.TAir_nominal_sh = TAir_nominal_sh
         self.nelements = nelements
-        self.initialize_UA = initialize_UA
+        # An explicit UA (a fitted value coming back from a serialized model)
+        # is the value; solving the nominal-output UA at initialize would
+        # overwrite it.
+        self.initialize_UA = initialize_UA if UA is None else False
         self.UA = tps.Parameter(
-            torch.tensor(10.0, dtype=tps.float_dtype()), requires_grad=False
+            torch.tensor(10.0 if UA is None else float(UA), dtype=tps.float_dtype()),
+            requires_grad=False,
         )  # Placeholder, will be set in initialize if initialize_UA is True
         self.thermalMassHeatCapacity = tps.Parameter(
             torch.tensor(thermalMassHeatCapacity, dtype=tps.float_dtype()),

--- a/twin4build/tests/model/test_serialize_round_trip.py
+++ b/twin4build/tests/model/test_serialize_round_trip.py
@@ -1,0 +1,137 @@
+"""``Model.serialize()`` -> ``Model.load(filename=...)`` must give the model back.
+
+Regressions covered:
+
+* nested parameters (``thermal.C_wall``, ``mass.V``) are serialized as
+  dotted literals that no constructor accepts, and used to reload at their
+  class defaults;
+* ``SpaceHeaterSystem`` had no ``UA`` constructor argument, so a fitted UA
+  reloaded as the placeholder (and ``initialize`` then re-solved it);
+* a sensor's unit transformation is a callable, not a literal, and was
+  dropped -- a saved calibrated model replayed in raw units (#190).  It now
+  travels as an import path (``transformation_ref``).
+"""
+
+# Standard library imports
+import datetime
+import os
+import shutil
+import tempfile
+import unittest
+
+# Third party imports
+import pandas as pd
+import torch
+from dateutil import tz
+
+# Local application imports
+import twin4build as tb
+from twin4build.systems.building_space.building_space_system import BuildingSpaceSystem
+from twin4build.systems.schedule.schedule_system import ScheduleSystem
+from twin4build.systems.sensor.sensor_system import SensorSystem
+from twin4build.systems.space_heater.space_heater_system import SpaceHeaterSystem
+
+tb._IS_TESTING = True
+
+
+def celsius_from_deci(x):
+    """A module-level transformation: importable by name."""
+    return x / 10.0
+
+
+def _schedule(id_, value):
+    return ScheduleSystem(
+        id=id_,
+        weekday_ruleset={
+            "ruleset_start_minute": [], "ruleset_end_minute": [], "ruleset_start_hour": [],
+            "ruleset_end_hour": [], "ruleset_value": [], "ruleset_default_value": value,
+        },
+    )
+
+
+class TestSerializeRoundTrip(unittest.TestCase):
+    MODEL_ID = "test_serialize_round_trip"
+    START = datetime.datetime(2023, 1, 1, tzinfo=tz.UTC)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+        index = pd.date_range(cls.START, periods=13, freq="10min", tz="UTC")
+        pd.DataFrame({"time": index, "value": [50.0 + i for i in range(13)]}).to_csv(
+            os.path.join(cls.tmp, "outdoor.csv"), index=False
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmp, ignore_errors=True)
+        for mid in (cls.MODEL_ID, cls.MODEL_ID + "_reloaded"):
+            path = os.path.join("generated_files", "models", mid)
+            if os.path.exists(path):
+                shutil.rmtree(path, ignore_errors=True)
+
+    def _build(self):
+        model = tb.Model(id=self.MODEL_ID)
+        room = BuildingSpaceSystem(
+            id="room", C_wall=1e6, C_air=1e4, C_boundary=5e5, R_out=0.01, R_in=0.02, R_boundary=0.03,
+            f_wall=0.5, f_air=0.3, Q_occ_gain=100.0, CO2_occ_gain=0.004, CO2_start=400.0, airVolume=100.0,
+            T_wall_start=20.0, T_air_start=20.0, T_int_start=20.0, T_boundary_start=18.0,
+        )
+        heater = SpaceHeaterSystem(id="heater")
+        outdoor = SensorSystem(
+            id="outdoor_sensor",
+            filename=os.path.join(self.tmp, "outdoor.csv"),
+            datecolumn=0, valuecolumn=1,
+            use_spreadsheet=True,
+            transformation=celsius_from_deci,
+        )
+        model.add_connection(outdoor, room, "measuredValue", "outdoorTemperature")
+        model.add_connection(_schedule("people", 0.0), room, "scheduleValue", "numberOfPeople")
+        model.add_connection(_schedule("sun", 0.0), room, "scheduleValue", "globalIrradiation")
+        model.add_connection(_schedule("flow", 0.05), room, "scheduleValue", "supplyAirFlowRate")
+        model.add_connection(_schedule("t_sup", 18.0), room, "scheduleValue", "supplyAirTemperature")
+        model.add_connection(_schedule("water", 0.01), heater, "scheduleValue", "waterFlowRate")
+        model.add_connection(_schedule("t_water", 60.0), heater, "scheduleValue", "supplyWaterTemperature")
+        model.add_connection(room, heater, "indoorTemperature", "indoorTemperature")
+        model.add_connection(heater, room, "Power", "heatGain")
+        model.load()
+        # "Fitted" values, nested and flat, written the way the estimator writes them.
+        model.simulation_model.set_parameters(
+            [4.2e6, 150.0, 37.5, 2.5e5],
+            [room, room, heater, heater],
+            ["thermal.C_wall", "mass.V", "UA", "thermalMassHeatCapacity"],
+            overwrite=True,
+        )
+        heater.initialize_UA = False
+        return model, room, heater, outdoor
+
+    def _simulate(self, model):
+        sim = tb.Simulator(model, execution_mode="object")
+        sim.simulate(
+            start_time=self.START, end_time=self.START + datetime.timedelta(hours=2),
+            step_size=600, show_progress_bar=False,
+        )
+        return model.components["room"].output["indoorTemperature"]._history.detach().clone()
+
+    def test_values_transformation_and_simulation_survive(self):
+        model, room, heater, outdoor = self._build()
+        reference = self._simulate(model)
+        model.serialize()
+        path, _ = model._simulation_model._semantic_model.get_dir(filename="instance_graph.ttl")
+
+        reloaded = tb.Model(id=self.MODEL_ID + "_reloaded")
+        reloaded.load(filename=path)
+        self.assertEqual(set(reloaded.components), set(model.components))
+        room2, heater2, outdoor2 = (reloaded.components[k] for k in ("room", "heater", "outdoor_sensor"))
+        self.assertAlmostEqual(float(room2.thermal.C_wall.get().reshape(-1)[0]), 4.2e6, delta=1.0)
+        self.assertAlmostEqual(float(room2.mass.V.get().reshape(-1)[0]), 150.0, places=6)
+        self.assertAlmostEqual(float(heater2.UA.get().reshape(-1)[0]), 37.5, places=6)
+        self.assertAlmostEqual(float(heater2.thermalMassHeatCapacity.get().reshape(-1)[0]), 2.5e5, delta=1e-3)
+        self.assertFalse(heater2.initialize_UA)
+        self.assertIs(outdoor2.transformation, celsius_from_deci)
+        self.assertEqual(outdoor2.transformation_ref, f"{__name__}:celsius_from_deci")
+
+        torch.testing.assert_close(self._simulate(reloaded), reference)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #190.

`Model.serialize()` -> `Model.load(filename=...)` gave back a model with the right components and connections but the wrong numbers: a calibrated model replayed with its class defaults and raw units, and nothing warned. Found while saving the fitted HTR model after a Stage 2 fit (zones came back at 100 C).

Four defects, one fix each:

1. **Nested parameters reloaded at defaults.** The literals are the flattened `populate_config()`, so `thermal.C_wall`, `mass.V`, `supply_damper.a` arrive as dotted keys that no constructor accepts and vanish into `**kwargs`. The loader now writes every literal that resolves to a `tps.Parameter` / `tps.TensorParameter` on the built component after construction: a scalar in place, a per-branch list (an AHU's damper parameters, `n_c > 1`) as a parameter of that width, which the owner's `initialize` then finds already expanded. A failure names the component and literal.
2. **`SpaceHeaterSystem` had no `UA` argument** (the literal was swallowed) and `initialize` re-solved UA from the nominal output anyway. `UA` is now a constructor argument; an explicit value disables the nominal solve.
3. **`populate_config` wrote a `TensorParameter`'s repr** (`"<twin4build.utils.types.TensorParameter object at ...>"`) once the estimator's `set_parameters(overwrite=True)` had replaced the `nn.Parameter` -- exactly the state a model is in after a fit. Values are read through `get()` for both parameter kinds.
4. **Sensor unit transformations were dropped** (a callable is not a literal), and `set_transformations` cannot be re-applied on a reloaded model (no `sim2sem_map`). A sensor now carries `transformation_ref` (`module:qualname`) in its config; it is emitted at serialize time for a module-level callable (a lambda / closure warns and is skipped) and re-imported by the constructor on load.

Test: `tests/model/test_serialize_round_trip.py` -- a zone + radiator + spreadsheet sensor with a transformation, "fitted" values written the way the estimator writes them (nested and flat, `overwrite=True`), serialized, reloaded into a fresh `Model`: same component ids, C_wall / V / UA / thermalMassHeatCapacity equal, `initialize_UA` off, the transformation re-bound to the same function, and the 2-hour simulation identical.

On the HTR model (99 components) the round-trip is now exact: same ids, all fitted literals back, identical playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
