### PR TITLE
feat: one AHU branch per VAV, zone air-flow ports as Vectors summed inside the zone (#179)

### DIFF
--- a/twin4build/model/simulation_model/simulation_model.py
+++ b/twin4build/model/simulation_model/simulation_model.py
@@ -79,6 +79,15 @@ def _check_id(id: str, kind: str) -> None:
     )
 
 
+def _index_literal(idx):
+    """A port index as a literal: an int, a list for a multi-slot tensor."""
+    if isinstance(idx, torch.Tensor):
+        return idx.item() if idx.numel() == 1 else idx.reshape(-1).tolist()
+    if isinstance(idx, int):
+        return int(idx)
+    return idx
+
+
 def _convert_literal_value(value):
     """
     Convert an RDF literal value to its appropriate Python type.
@@ -776,6 +785,11 @@ class SimulationModel:
         else:
             if isinstance(other_port, tps.Vector) and isinstance(this_port, tps.Vector):
                 return torch.arange(this_port.size)  # Map directly
+            elif isinstance(this_port, tps.Vector) and isinstance(other_port, tps.Scalar):
+                # A scalar into a Vector port without an index takes slot 0:
+                # the single-branch case (one damper feeding one zone) needs
+                # no index, exactly as it did when the port was a Scalar.
+                return 0
             else:
                 assert isinstance(this_port, tps.Scalar), (
                     f"If {this_port_name} port index is not set, both output and input ports "
@@ -783,6 +797,42 @@ class SimulationModel:
                     f"and {this_port_name} port type {this_port.__class__.__name__}"
                 )
                 return None
+
+    def _merge_vector_connection(
+        self,
+        sender_component,
+        receiver_component,
+        connection,
+        connection_point,
+        output_port,
+        input_port,
+        output_port_index,
+        input_port_index,
+        message,
+    ) -> None:
+        """Append one more slot pair to an existing Vector -> Vector connection."""
+        this_out = sender_component.output[output_port]
+        this_in = receiver_component.input[input_port]
+        assert (
+            isinstance(this_out, tps.Vector)
+            and isinstance(this_in, tps.Vector)
+            and output_port_index is not None
+            and input_port_index is not None
+        ), message
+
+        def _as_1d(index):
+            return torch.as_tensor(index, dtype=torch.long).reshape(-1)
+
+        old_in = _as_1d(connection_point.input_port_index[connection])
+        old_out = _as_1d(connection_point.output_port_index[connection])
+        new_in = _as_1d(input_port_index)
+        new_out = _as_1d(output_port_index)
+        assert new_in.numel() == new_out.numel(), message
+        assert not bool(torch.isin(new_in, old_in).any()), (
+            f"{message} (slot {new_in.tolist()} of {input_port} is already wired)"
+        )
+        connection_point.set_input_port_index(connection, torch.cat([old_in, new_in]))
+        connection_point.set_output_port_index(connection, torch.cat([old_out, new_out]))
 
     def add_connection(
         self,
@@ -845,10 +895,28 @@ class SimulationModel:
 
         if found_connection_point and found_connection:
             message = f'core.Connection between "{sender_component.id}" and "{receiver_component.id}" with the properties "{output_port}" and "{input_port}" already exists.'
-            assert (
+            if (
                 receiver_component_connection_point
-                not in sender_obj_connection.connects_system_at
-            ), message
+                in sender_obj_connection.connects_system_at
+            ):
+                # The same output -> input pair again, on other slots: a
+                # zone served by several branches of one AHU reads
+                # ``ahu.supplyAirFlowRate[b] -> zone.supplyAirFlowRate[k]``
+                # once per branch.  One Connection carries all of them as
+                # tensor indices (the Vector -> Vector form the engines
+                # already route); anything else is a genuine duplicate.
+                self._merge_vector_connection(
+                    sender_component,
+                    receiver_component,
+                    sender_obj_connection,
+                    receiver_component_connection_point,
+                    output_port,
+                    input_port,
+                    output_port_index,
+                    input_port_index,
+                    message,
+                )
+                return
 
         if found_connection == False:
             sender_obj_connection = core.Connection(
@@ -3371,15 +3439,11 @@ class SimulationModel:
             literals_to_update = {
                 "input_port": connection_point.input_port,
                 "input_port_index": {
-                    str(hash(conn)): (
-                        int(idx) if isinstance(idx, (int, torch.Tensor)) else idx
-                    )
+                    str(hash(conn)): _index_literal(idx)
                     for conn, idx in connection_point.input_port_index.items()
                 },
                 "output_port_index": {
-                    str(hash(conn)): (
-                        int(idx) if isinstance(idx, (int, torch.Tensor)) else idx
-                    )
+                    str(hash(conn)): _index_literal(idx)
                     for conn, idx in connection_point.output_port_index.items()
                 },
             }
@@ -3821,6 +3885,11 @@ class SimulationModel:
 
                     receiver_component_id = receiver_component.get_short_name()
                     receiver_component = self._components[receiver_component_id]
+                    # Multi-slot (tensor) indices are serialized as lists.
+                    if isinstance(input_port_index, list):
+                        input_port_index = torch.tensor(input_port_index, dtype=torch.long)
+                    if isinstance(output_port_index, list):
+                        output_port_index = torch.tensor(output_port_index, dtype=torch.long)
 
                     pending_connections.append(
                         {

--- a/twin4build/model/simulation_model/simulation_model.py
+++ b/twin4build/model/simulation_model/simulation_model.py
@@ -886,6 +886,16 @@ class SimulationModel:
                 found_connection_point = True
                 break
 
+        # Vector -> Vector with a slot on one side only: the other side is a
+        # single-slot port (a one-branch zone reading one AHU branch), slot 0.
+        if isinstance(sender_component.output[output_port], tps.Vector) and isinstance(
+            receiver_component.input[input_port], tps.Vector
+        ):
+            if isinstance(output_port_index, int) and input_port_index is None:
+                input_port_index = 0
+            elif isinstance(input_port_index, int) and output_port_index is None:
+                output_port_index = 0
+
         found_connection = False
         # Check if there already is a connection with the same sender_property_name
         for sender_obj_connection in sender_component.connected_through:

--- a/twin4build/simulator/_functional.py
+++ b/twin4build/simulator/_functional.py
@@ -630,20 +630,30 @@ class FunctionalModel:
             if cp.input_port != port:
                 continue
             for conn in cp.connects_system_through:
-                idx = cp.input_port_index.get(conn, 0)
-                idx = int(idx.item()) if hasattr(idx, "item") else int(idx)
+                in_idx = cp.input_port_index.get(conn, 0)
+                out_idx = cp.output_port_index.get(conn, slice(None))
+                if isinstance(in_idx, torch.Tensor) and in_idx.numel() > 1:
+                    # One connection, several slot pairs (a zone fed by
+                    # several branches of one AHU): each input slot has its
+                    # own output slot.
+                    pairs = list(zip(in_idx.reshape(-1).tolist(), out_idx.reshape(-1).tolist()))
+                else:
+                    idx = int(in_idx.item()) if hasattr(in_idx, "item") else int(in_idx)
+                    pairs = [(idx, out_idx)]
                 immediate = self._connection_sources(comp, port)
                 for src in immediate:
                     if src[0] is conn.connects_system and src[1] == conn.output_port:
                         followed = self._follow(src[0], src[1])
                         if followed is not None:
-                            slots.setdefault(idx, []).append(
-                                (
-                                    followed[0],
-                                    followed[1],
-                                    followed[2] + src[2],
+                            for idx, o in pairs:
+                                route = (o,) + tuple(src[2][0][1:])
+                                slots.setdefault(idx, []).append(
+                                    (
+                                        followed[0],
+                                        followed[1],
+                                        followed[2] + (route,),
+                                    )
                                 )
-                            )
                         break
         return sorted(slots.items())
 

--- a/twin4build/systems/air_handling_unit/air_handling_unit_system.py
+++ b/twin4build/systems/air_handling_unit/air_handling_unit_system.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import datetime
 
 # Third party imports
+import torch
 import torch.nn as nn  # noqa: F401 - torch needed for tensor ops
 
 # Local application imports
@@ -291,6 +292,10 @@ class AirHandlingUnitSystem(core.System, nn.Module):
             else:
                 output_port.initialize(n_t=max_timesteps, n_s=batch_size)
 
+        # Exhaust branches read their room's exhaust temperature through the
+        # branch -> room map (None when the two are aligned one-to-one).
+        self._branch_room_index = self._exhaust_branch_map(n_v_exhaust)
+
         # Set n_c for damper subcomponents: n_c_ahu * n_v (flattened from Vector shape)
         # Supply and exhaust can have different n_v values
         self.supply_damper.n_c = self.n_c * n_v_supply
@@ -310,6 +315,61 @@ class AirHandlingUnitSystem(core.System, nn.Module):
         self.supply_fan.initialize(start_time, end_time, step_size)
         self.exhaust_fan.initialize(start_time, end_time, step_size)
         self.INITIALIZED = True
+
+    def _exhaust_branch_map(self, n_v_exhaust: int):
+        """``LongTensor`` mapping each exhaust branch to the slot of
+        ``exhaustTemperature`` that carries its room's temperature, or
+        ``None`` when the two are aligned one-to-one (as many temperature
+        slots as branches -- the hand-built and single-VAV cases).
+
+        The map is read off the wiring: branch ``b`` belongs to the zone
+        that consumes ``supplyAirFlowRate[b]``, and that zone's slot on
+        ``exhaustTemperature`` is where it publishes ``indoorTemperature``.
+        """
+        n_v_temp = self.input["exhaustTemperature"].n_v
+        if n_v_temp == n_v_exhaust or n_v_temp is None:
+            return None
+        temp_slot_of = {}
+        for cp in self.connects_at:
+            if cp.input_port != "exhaustTemperature":
+                continue
+            for conn in cp.connects_system_through:
+                idx = cp.input_port_index.get(conn, 0)
+                temp_slot_of[id(conn.connects_system)] = int(
+                    idx.reshape(-1)[0].item() if hasattr(idx, "reshape") else idx
+                )
+        index = [None] * n_v_exhaust
+        for conn in self.connected_through:
+            if conn.output_port != "supplyAirFlowRate":
+                continue
+            for cp in conn.connects_system_at:
+                slot = temp_slot_of.get(id(cp.connection_point_of))
+                if slot is None:
+                    continue
+                branches = cp.output_port_index.get(conn, 0)
+                branches = (
+                    branches.reshape(-1).tolist()
+                    if hasattr(branches, "reshape")
+                    else [int(branches)]
+                )
+                for b in branches:
+                    if b < n_v_exhaust:
+                        index[b] = slot
+        if any(i is None for i in index):
+            missing = [b for b, i in enumerate(index) if i is None]
+            raise ValueError(
+                f"|{self.__class__.__name__}|{self.id}|: exhaustTemperature has "
+                f"{n_v_temp} slots for {n_v_exhaust} exhaust branches, and branches "
+                f"{missing} cannot be mapped to a room (no zone consumes their "
+                "supplyAirFlowRate and publishes its exhaust temperature)."
+            )
+        return torch.tensor(index, dtype=torch.long)
+
+    def _per_branch_exhaust_temperature(self, exhaust_temperature):
+        index = getattr(self, "_branch_room_index", None)
+        if index is None:
+            return exhaust_temperature
+        return exhaust_temperature[..., index.to(exhaust_temperature.device)]
 
     def do_step(
         self,
@@ -357,7 +417,9 @@ class AirHandlingUnitSystem(core.System, nn.Module):
         exhaust_flow_vec = exhaust_flow_flat.reshape(exhaust_pos_vec.shape)
 
         # 4) Return junction: combine exhaust flows and temperatures
-        exhaust_temp_vec = self.input["exhaustTemperature"].get()
+        exhaust_temp_vec = self._per_branch_exhaust_temperature(
+            self.input["exhaustTemperature"].get()
+        )
         self.return_junction.input["airFlowRateIn"].set(exhaust_flow_vec, step_index)
         self.return_junction.input["airTemperatureIn"].set(exhaust_temp_vec, step_index)
         self.return_junction.do_step(second_time, date_time, step_size, step_index)
@@ -507,7 +569,9 @@ class AirHandlingUnitSystem(core.System, nn.Module):
             None,
             {
                 "airFlowRateIn": exhaust_flow_vec,
-                "airTemperatureIn": inputs["exhaustTemperature"],
+                "airTemperatureIn": self._per_branch_exhaust_temperature(
+                    inputs["exhaustTemperature"]
+                ),
             },
             P["return_junction"],
             sample_time,
@@ -831,15 +895,13 @@ def brick_signature_pattern_vav_dampers():
         )
     )
 
-    # All Vector inputs are indexed by ``spaces`` so the BuildingSpace
-    # pattern (which uses ``output_port_index=space`` when reading from
-    # the AHU's ``supplyAirFlowRate`` Vector output) shares a common
-    # SP-side node identity with this pattern.  Mixing index keys
-    # (``vavs`` here, ``spaces`` over there) leaves the translator
-    # unable to map BuildingSpace.space to an AHU output slot, which
-    # surfaces as a ``Vector -> Scalar with no index`` assertion in
-    # ``add_connection`` for unrelated edges like
-    # ``ahu.supplyAirFlowRate -> RM107A.supplyAirFlowRate``.
+    # Branches are indexed by ``vavs`` -- one damper, one branch, one
+    # calibratable nominal flow per VAV (issue #179) -- and the zone reads
+    # its branches back with the same key (``output_port_index=vav`` in the
+    # BuildingSpace pattern, one slot per VAV of its Vector flow ports).
+    # ``exhaustTemperature`` stays indexed by ``spaces``: a room has one
+    # exhaust temperature however many branches serve it, and the AHU maps
+    # branch -> room itself (``_exhaust_branch_map``).
     sp.add_connection(
         spaces, "indoorTemperature", "exhaustTemperature", input_port_index=spaces
     )
@@ -867,14 +929,14 @@ def brick_signature_pattern_vav_dampers():
         "inputSignal",
         "supplyDamperPosition",
         output_port_index=damper_cmds,
-        input_port_index=spaces,
+        input_port_index=vavs,
     )
     sp.add_connection(
         damper_cmds,
         "inputSignal",
         "exhaustDamperPosition",
         output_port_index=damper_cmds,
-        input_port_index=spaces,
+        input_port_index=vavs,
     )
     sp.add_connection(sat_setpoint, "measuredValue", "supplyAirTemperatureSetpoint")
     sp.add_connection(oat_sensor, "outdoorTemperature", "outdoorAirTemperature")
@@ -978,14 +1040,14 @@ def brick_signature_pattern_vav_damper_commands():
         "inputSignal",
         "supplyDamperPosition",
         output_port_index=damper_cmds,
-        input_port_index=spaces,
+        input_port_index=vavs,
     )
     sp.add_connection(
         damper_cmds,
         "inputSignal",
         "exhaustDamperPosition",
         output_port_index=damper_cmds,
-        input_port_index=spaces,
+        input_port_index=vavs,
     )
     sp.add_connection(sat_setpoint, "measuredValue", "supplyAirTemperatureSetpoint")
     sp.add_connection(oat_sensor, "outdoorTemperature", "outdoorAirTemperature")

--- a/twin4build/systems/building_space/building_space_system.py
+++ b/twin4build/systems/building_space/building_space_system.py
@@ -16,6 +16,7 @@ from twin4build.systems.building_space.building_space_thermal_system import (
     BuildingSpaceThermalSystem,
 )
 from twin4build.translator.translator import (
+    SetStepRule,
     StepRule,
     AnyPathRule,
     Node,
@@ -142,6 +143,13 @@ class BuildingSpaceSystem(core.System, nn.Module):
             shared = self._input[k]
             self.thermal.input[k] = shared
             self.mass.input[k] = shared
+        # The air-flow ports are Vectors on the composite -- one slot per
+        # branch (VAV) serving the zone -- and are summed into the submodels'
+        # shared scalar ports in ``do_step`` / ``forward``.  A lumped zone
+        # only sees the total, but every branch keeps its own damper and its
+        # own calibratable nominal flow (issue #179).
+        for k in self._FLOW_PORTS:
+            self._input[k] = tps.Vector()
         self._output = {**self.thermal.output, **self.mass.output}
         for k in set(self.thermal.output) & set(self.mass.output):
             shared = self._output[k]
@@ -224,6 +232,16 @@ class BuildingSpaceSystem(core.System, nn.Module):
             self.thermal.n_walls = n_walls
             self.thermal.n_boundary_temperature = n_boundary_temperature
 
+        _, _, max_timesteps, _ = core.Simulator.get_simulation_timesteps(
+            start_time, end_time, step_size
+        )
+        for k in self._FLOW_PORTS:
+            self.input[k].initialize(
+                n_t=max_timesteps,
+                n_s=len(start_time),
+                n_c=getattr(self, "n_c", 1) or 1,
+                n_v=self.get_n_v_from_connections(k) or 1,
+            )
         self.thermal.initialize(start_time, end_time, step_size)
         self.mass.initialize(start_time, end_time, step_size)
         # Drop the per-params routing cache (fresh graph per run, like the
@@ -235,6 +253,9 @@ class BuildingSpaceSystem(core.System, nn.Module):
     def config(self):
         """Get the system configuration."""
         return self._config
+
+    #: Vector input ports of the composite, summed into the submodels.
+    _FLOW_PORTS = ("supplyAirFlowRate", "exhaustAirFlowRate")
 
     def do_step(
         self,
@@ -263,6 +284,9 @@ class BuildingSpaceSystem(core.System, nn.Module):
         only correct *because* it bypassed the aliasing problem, and is
         redundant once the aliases are guaranteed.
         """
+        for k in self._FLOW_PORTS:
+            # The submodels share one scalar port per flow: the total.
+            self.thermal.input[k].set(self.input[k].get().sum(dim=-1), step_index)
         self.thermal.do_step(second_time, date_time, step_size, step_index=step_index)
         self.mass.do_step(second_time, date_time, step_size, step_index=step_index)
 
@@ -304,6 +328,14 @@ class BuildingSpaceSystem(core.System, nn.Module):
         """
         n_th = self.thermal.state_size()
         x_th, x_ma = x[..., :n_th], x[..., n_th:]
+        # Vector flow ports carry one trailing branch axis more than the
+        # scalar ports; sum it away for the submodels.
+        ref_dim = inputs["outdoorTemperature"].dim()
+        inputs = dict(inputs)
+        for k in self._FLOW_PORTS:
+            v = inputs.get(k)
+            if v is not None and v.dim() > ref_dim:
+                inputs[k] = v.sum(dim=-1)
         # Identity-keyed cache: a sequential rollout re-calls forward with the
         # SAME params dict every step (see OneStepComposer._params_for), so
         # the sub-param routing -- and, downstream, the submodels' state-space
@@ -626,12 +658,28 @@ def _brick_space_pattern(topology: str, with_volume: bool, heat_source: str = "c
         else:
             raise ValueError(topology)
 
-    sp.add_connection(
-        ahu, "supplyAirFlowRate", "supplyAirFlowRate", output_port_index=space
-    )
-    sp.add_connection(
-        ahu, "exhaustAirFlowRate", "exhaustAirFlowRate", output_port_index=space
-    )
+    # One AHU branch per VAV: the zone's Vector flow ports get one slot per
+    # VAV serving it (``input_port_index=vav``), read from that VAV's branch
+    # of the AHU (``output_port_index=vav``, the key the AHU damper pattern
+    # indexes its branches by).  The direct topology has no VAV: the AHU's
+    # single branch for the space lands in slot 0.
+    if topology == "direct":
+        sp.add_connection(ahu, "supplyAirFlowRate", "supplyAirFlowRate", output_port_index=space)
+        sp.add_connection(ahu, "exhaustAirFlowRate", "exhaustAirFlowRate", output_port_index=space)
+    else:
+        # The room's VAVs as a set (one group per VAV, in lockstep with the
+        # AHU pattern's ``vavs``): each VAV is a distinct slot of the zone's
+        # Vector flow ports and a distinct branch of the AHU.
+        vavs = Node(cls=core.namespace.BRICK.VAV)
+        sp.add_rule(SetStepRule(subject=space, object=vavs, predicate=core.namespace.BRICK.isFedBy))
+        sp.add_connection(
+            ahu, "supplyAirFlowRate", "supplyAirFlowRate",
+            output_port_index=vavs, input_port_index=vavs,
+        )
+        sp.add_connection(
+            ahu, "exhaustAirFlowRate", "exhaustAirFlowRate",
+            output_port_index=vavs, input_port_index=vavs,
+        )
     sp.add_connection(solar_radiance_sensor, "globalIrradiation", "globalIrradiation")
     sp.add_connection(
         outside_air_temperature_sensor, "outdoorTemperature", "outdoorTemperature"

--- a/twin4build/systems/sensor/sensor_system.py
+++ b/twin4build/systems/sensor/sensor_system.py
@@ -971,7 +971,7 @@ def get_brick_supply_air_flow_sensor_with_ref_pattern():
         ahu,
         "supplyAirFlowRate",
         "measuredValue",
-        output_port_index=room,
+        output_port_index=vav,
     )
     sp.add_modeled_node(sensor)
     sp.add_modeled_node(externalref)
@@ -1030,7 +1030,7 @@ def get_brick_supply_air_flow_sensor_virtual_pattern():
         ahu,
         "supplyAirFlowRate",
         "measuredValue",
-        output_port_index=room,
+        output_port_index=vav,
     )
     sp.add_modeled_node(sensor)
     return sp

--- a/twin4build/systems/utils/fused_statespace_system.py
+++ b/twin4build/systems/utils/fused_statespace_system.py
@@ -608,7 +608,17 @@ class FusedStateSpaceSystem(core.System, nn.Module):
             matrices = cache[1]
             disc_cache = cache[3]
         A, B, C, D, E, F = matrices
-        u = torch.stack([inputs[name] for name in self._ext_names], dim=-1)
+        # A member's Vector input (a zone's per-branch air flows) enters the
+        # fused input vector as its total: the state-space units declare one
+        # column for it, and the zone itself sums the branches.
+        n_lead = x.dim() - 1
+        u = torch.stack(
+            [
+                inputs[name].sum(dim=-1) if inputs[name].dim() > n_lead else inputs[name]
+                for name in self._ext_names
+            ],
+            dim=-1,
+        )
         x_next, y = bilinear_onestep(
             A,
             B,

--- a/twin4build/tests/systems/building_space/test_vector_flow_ports.py
+++ b/twin4build/tests/systems/building_space/test_vector_flow_ports.py
@@ -1,0 +1,141 @@
+"""A zone served by several AHU branches (issue #179).
+
+The zone's ``supplyAirFlowRate`` / ``exhaustAirFlowRate`` are Vector ports,
+one slot per branch, summed inside the zone; the AHU keeps one branch per
+damper and maps each exhaust branch to its room's exhaust temperature.  One
+``add_connection`` per branch on the same output -> input pair merges into a
+single connection with tensor slot indices, which both engines route.
+"""
+
+# Standard library imports
+import datetime
+import unittest
+
+# Third party imports
+import torch
+from dateutil import tz
+
+# Local application imports
+import twin4build as tb
+from twin4build.systems.air_handling_unit.air_handling_unit_system import (
+    AirHandlingUnitSystem,
+)
+from twin4build.systems.building_space.building_space_system import BuildingSpaceSystem
+from twin4build.systems.schedule.schedule_system import ScheduleSystem
+
+tb._IS_TESTING = True
+
+
+def _schedule(id_, value):
+    return ScheduleSystem(
+        id=id_,
+        weekday_ruleset={
+            "ruleset_start_minute": [], "ruleset_end_minute": [], "ruleset_start_hour": [],
+            "ruleset_end_hour": [], "ruleset_value": [], "ruleset_default_value": value,
+        },
+    )
+
+
+def _zone(id_):
+    return BuildingSpaceSystem(
+        id=id_, C_wall=1e6, C_air=1e4, C_boundary=5e5, R_out=0.01, R_in=0.02, R_boundary=0.03,
+        f_wall=0.5, f_air=0.3, Q_occ_gain=100.0, CO2_occ_gain=0.004, CO2_start=400.0, airVolume=100.0,
+        T_wall_start=20.0, T_air_start=20.0, T_int_start=20.0, T_boundary_start=18.0,
+    )
+
+
+def build_model(model_id):
+    model = tb.Model(id=model_id)
+    ahu = AirHandlingUnitSystem(
+        id="ahu",
+        damper_kwargs={"a": 1.0, "nominalAirFlowRate": 0.5},
+        heat_recovery_kwargs={
+            "eps_75_h": 0.7, "eps_100_h": 0.75, "eps_75_c": 0.65, "eps_100_c": 0.7,
+            "primaryAirFlowRateMax": 1.0, "secondaryAirFlowRateMax": 1.0,
+        },
+        supply_fan_kwargs={
+            "nominalPowerRate": 1000.0, "nominalAirFlowRate": 1, "c1": 0, "c2": 0.2, "c3": 0.8, "c4": 0, "f_total": 1.0,
+        },
+        exhaust_fan_kwargs={
+            "nominalPowerRate": 1000.0, "nominalAirFlowRate": 1, "c1": 0, "c2": 0.2, "c3": 0.8, "c4": 0, "f_total": 1.0,
+        },
+        n_branches=3,
+    )
+    # Three dampers: branch 0 serves zone A, branches 1 and 2 serve zone B.
+    for slot, value in ((0, 0.8), (1, 0.4), (2, 0.6)):
+        damper = _schedule(f"damper_{slot}", value)
+        model.add_connection(damper, ahu, "scheduleValue", "supplyDamperPosition", input_port_index=slot)
+        model.add_connection(damper, ahu, "scheduleValue", "exhaustDamperPosition", input_port_index=slot)
+    model.add_connection(_schedule("t_sup", 18.0), ahu, "scheduleValue", "supplyAirTemperatureSetpoint")
+    model.add_connection(_schedule("t_out", 5.0), ahu, "scheduleValue", "outdoorAirTemperature")
+    zones = {"A": _zone("zone_a"), "B": _zone("zone_b")}
+    # Zone A: one branch, no index needed on the scalar side; zone B: two
+    # branches into its Vector flow ports, one add_connection per branch.
+    model.add_connection(ahu, zones["A"], "supplyAirFlowRate", "supplyAirFlowRate", output_port_index=0, input_port_index=0)
+    model.add_connection(ahu, zones["A"], "exhaustAirFlowRate", "exhaustAirFlowRate", output_port_index=0, input_port_index=0)
+    for k, branch in enumerate((1, 2)):
+        model.add_connection(ahu, zones["B"], "supplyAirFlowRate", "supplyAirFlowRate", output_port_index=branch, input_port_index=k)
+        model.add_connection(ahu, zones["B"], "exhaustAirFlowRate", "exhaustAirFlowRate", output_port_index=branch, input_port_index=k)
+    # Exhaust temperature: one slot per zone.
+    for slot, zone in enumerate(zones.values()):
+        model.add_connection(zone, ahu, "indoorTemperature", "exhaustTemperature", input_port_index=slot)
+    for name, zone in zones.items():
+        model.add_connection(ahu, zone, "supplyAirTemperature", "supplyAirTemperature")
+        model.add_connection(_schedule(f"t_out_{name}", 5.0), zone, "scheduleValue", "outdoorTemperature")
+        model.add_connection(_schedule(f"people_{name}", 2.0), zone, "scheduleValue", "numberOfPeople")
+        model.add_connection(_schedule(f"sun_{name}", 0.0), zone, "scheduleValue", "globalIrradiation")
+        model.add_connection(_schedule(f"gain_{name}", 0.0), zone, "scheduleValue", "heatGain")
+    model.load()
+    return model, ahu, zones
+
+
+class TestVectorFlowPorts(unittest.TestCase):
+    START = datetime.datetime(2023, 1, 1, tzinfo=tz.UTC)
+
+    def _kwargs(self):
+        return dict(start_time=self.START, end_time=self.START + datetime.timedelta(hours=2), step_size=600, show_progress_bar=False)
+
+    def test_merged_connection_and_branch_map(self):
+        model, ahu, zones = build_model("vector_flow_ports_topology")
+        (cp,) = [cp for cp in zones["B"].connects_at if cp.input_port == "supplyAirFlowRate"]
+        (conn,) = cp.connects_system_through
+        self.assertEqual(cp.input_port_index[conn].tolist(), [0, 1])
+        self.assertEqual(cp.output_port_index[conn].tolist(), [1, 2])
+        tb.Simulator(model, execution_mode="object").simulate(**self._kwargs())
+        self.assertEqual(zones["B"].input["supplyAirFlowRate"].n_v, 2)
+        self.assertEqual(ahu._branch_room_index.tolist(), [0, 1, 1])
+
+    def test_zone_sums_its_branches_and_engines_agree(self):
+        model, ahu, zones = build_model("vector_flow_ports_parity")
+        tb.Simulator(model, execution_mode="object").simulate(**self._kwargs())
+        branch_flows = ahu.output["supplyAirFlowRate"]._history.detach().clone()  # (n_t, n_s, n_c, 3)
+        zone_b_slots = zones["B"].input["supplyAirFlowRate"]._history.detach().clone()
+        # zone -> AHU (exhaust temperature) -> zone (flow) is a cycle; the
+        # zone executes first and reads the AHU's previous step (Gauss-Seidel
+        # lag), so slot k of zone B at step t is branch k+1 at step t-1.
+        torch.testing.assert_close(zone_b_slots[1:, ..., 0], branch_flows[:-1, ..., 1])
+        torch.testing.assert_close(zone_b_slots[1:, ..., 1], branch_flows[:-1, ..., 2])
+        # The submodels see the total.
+        torch.testing.assert_close(
+            zones["B"].thermal.input["supplyAirFlowRate"]._history.reshape(zone_b_slots.shape[:-1]),
+            zone_b_slots.sum(dim=-1),
+        )
+        # Branches 1 and 2 carry more air than branch 0 (dampers 0.4 + 0.6 > 0.8),
+        # so zone B must be ventilated harder than zone A.
+        self.assertGreater(float(zone_b_slots.sum(dim=-1).mean()), float(branch_flows[..., 0].mean()))
+        t_object = {k: z.output["indoorTemperature"]._history.detach().clone() for k, z in zones.items()}
+        co2_object = {k: z.output["indoorCO2"]._history.detach().clone() for k, z in zones.items()}
+
+        tb.Simulator(model, execution_mode="functional").simulate(**self._kwargs())
+        for k, z in zones.items():
+            torch.testing.assert_close(z.output["indoorTemperature"]._history, t_object[k], rtol=1e-6, atol=1e-6)
+            torch.testing.assert_close(z.output["indoorCO2"]._history, co2_object[k], rtol=1e-6, atol=1e-4)
+        # The functional engine materialises input histories same-step (no
+        # Gauss-Seidel lag), so compare the routing, not the timing.
+        functional_slots = zones["B"].input["supplyAirFlowRate"]._history
+        self.assertEqual(tuple(functional_slots.shape), tuple(zone_b_slots.shape))
+        torch.testing.assert_close(functional_slots[1:], zone_b_slots[1:], rtol=1e-6, atol=1e-8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/twin4build/tests/translator/test_brick14_bms_patterns.py
+++ b/twin4build/tests/translator/test_brick14_bms_patterns.py
@@ -191,16 +191,11 @@ class TestBrick14BmsPatterns(unittest.TestCase):
             downstream = _outgoing_components(cits, "inputSignal")
             self.assertTrue(any(isinstance(c, SensorSystem) for c in downstream))
         self.assertEqual(sorted(gates), ["R01_SpFCI01_C", "R02_SpFCI01_C", "R02_SpFCI02_C"])
-        # ... and the AHU damper slot of each room is driven by exactly one
-        # of that room's controllers (one connection per Vector slot).
+        # ... and every controller drives its own AHU branch: one branch per
+        # VAV (issue #179), both damper ports of a branch driven by the SAME
+        # controller.
         drivers = [c for c in cits_list if ahu in _outgoing_components(c, "inputSignal")]
-        self.assertEqual(len(drivers), 2)
-        # ... and both damper ports of a zone slot are driven by the SAME
-        # controller.  Constraint 4 of the MILP bounds each port on its own,
-        # so R02's two VAVs could split that zone's ports between them, an
-        # equally optimal solution that solver tie-breaking picked on some
-        # platforms (three drivers instead of two); the slot-coherence
-        # constraint (4b) rules it out for every solver.
+        self.assertEqual(len(drivers), 3)
         driver_by_slot = {}
         for cp in ahu.connects_at:
             if cp.input_port not in ("supplyDamperPosition", "exhaustDamperPosition"):
@@ -208,12 +203,27 @@ class TestBrick14BmsPatterns(unittest.TestCase):
             for conn in cp.connects_system_through:
                 slot = int(cp.input_port_index[conn])
                 driver_by_slot.setdefault(slot, {})[cp.input_port] = conn.connects_system
-        self.assertEqual(len(driver_by_slot), 2)  # one slot per room
+        self.assertEqual(len(driver_by_slot), 3)  # one branch per VAV
         for slot, ports in driver_by_slot.items():
             self.assertEqual(
                 set(ports), {"supplyDamperPosition", "exhaustDamperPosition"}, slot
             )
             self.assertIs(ports["supplyDamperPosition"], ports["exhaustDamperPosition"])
+        # The exhaust temperature stays one slot per room; the AHU maps
+        # branch -> room itself.
+        self.assertEqual(len(incoming(ahu, "exhaustTemperature")), 2)
+        # A two-VAV room reads both of its branches into its Vector flow
+        # port (one connection, two slot pairs) ...
+        (cp,) = [cp for cp in rooms["R02"].connects_at if cp.input_port == "supplyAirFlowRate"]
+        (conn,) = cp.connects_system_through
+        self.assertEqual(sorted(cp.input_port_index[conn].tolist()), [0, 1])
+        self.assertEqual(len(set(cp.output_port_index[conn].tolist())), 2)
+        # ... and its flow sensors read those same branches.
+        branch_of = dict(zip(cp.input_port_index[conn].tolist(), cp.output_port_index[conn].tolist()))
+        for uuid in ("R02_FCI01", "R02_FCI02"):
+            (scp,) = [scp for scp in sensors[uuid].connects_at if scp.input_port == "measuredValue"]
+            (sconn,) = scp.connects_system_through
+            self.assertIn(int(scp.output_port_index[sconn]), branch_of.values())
 
         outdoor = by_cls["OutdoorEnvironmentSystem"][0]
         self.assertEqual(outdoor.uuid_outdoorTemperature, "WS01_TOUT")

--- a/twin4build/translator/translator.py
+++ b/twin4build/translator/translator.py
@@ -1555,7 +1555,7 @@ class Translator:
                                         # - input_port_index=Node (Scalar→Vector, Vector→Vector): find
                                         #   which slot in groups_target matches the semantic instance
 
-                                        sm_for_index = sm_subject  # Default: sender's semantic instance
+                                        sm_for_index_list = [sm_subject]  # Default: sender's semantic instance
 
                                         # Only override ``sm_for_index`` from the
                                         # tuple binding when *neither* port-index
@@ -1598,7 +1598,7 @@ class Translator:
                                                             )
                                                         )
                                                         if elements:
-                                                            sm_for_index = elements[0]
+                                                            sm_for_index_list = list(elements)
                                                         break
                                             elif isinstance(input_port_index, Node):
                                                 for group in groups:
@@ -1610,53 +1610,57 @@ class Translator:
                                                             )
                                                         )
                                                         if elements:
-                                                            sm_for_index = elements[0]
+                                                            sm_for_index_list = list(elements)
                                                         break
 
-                                        resolved_output_idx, resolved_input_idx = (
-                                            resolve_port_indices(
-                                                p_groups,
-                                                groups,
-                                                output_port_index,
-                                                input_port_index,
-                                                sm_for_index,
-                                            )
-                                        )
-
-                                        # Add this potential connection with resolved indices
-                                        conn = (
-                                            provider_component,
-                                            component,
-                                            source_key,
-                                            key,
-                                            resolved_output_idx,
-                                            resolved_input_idx,
-                                        )
-                                        E_idx_to_conn, E_conn_to_idx, N_E = (
-                                            update_E_mappings(
-                                                conn, E_idx_to_conn, E_conn_to_idx, N_E
-                                            )
-                                        )
-                                        self.E_conn_to_sp_group[conn] = (
-                                            sp,
-                                            groups,
-                                            p_sp,
-                                            p_groups,
-                                        )
-                                        if (
-                                            provider_component,
-                                            source_key,
-                                            resolved_output_idx,
-                                            resolved_input_idx,
-                                        ) not in required_inputs[component][key]:
-                                            required_inputs[component][key].append(
-                                                (
-                                                    provider_component,
-                                                    source_key,
-                                                    resolved_output_idx,
-                                                    resolved_input_idx,
+                                        # A set-bound index node that is not the sender
+                                        # (a zone's VAVs indexing the AHU's branches)
+                                        # yields one candidate edge per element.
+                                        for sm_for_index in sm_for_index_list:
+                                            resolved_output_idx, resolved_input_idx = (
+                                                resolve_port_indices(
+                                                    p_groups,
+                                                    groups,
+                                                    output_port_index,
+                                                    input_port_index,
+                                                    sm_for_index,
                                                 )
                                             )
+
+                                            # Add this potential connection with resolved indices
+                                            conn = (
+                                                provider_component,
+                                                component,
+                                                source_key,
+                                                key,
+                                                resolved_output_idx,
+                                                resolved_input_idx,
+                                            )
+                                            E_idx_to_conn, E_conn_to_idx, N_E = (
+                                                update_E_mappings(
+                                                    conn, E_idx_to_conn, E_conn_to_idx, N_E
+                                                )
+                                            )
+                                            self.E_conn_to_sp_group[conn] = (
+                                                sp,
+                                                groups,
+                                                p_sp,
+                                                p_groups,
+                                            )
+                                            if (
+                                                provider_component,
+                                                source_key,
+                                                resolved_output_idx,
+                                                resolved_input_idx,
+                                            ) not in required_inputs[component][key]:
+                                                required_inputs[component][key].append(
+                                                    (
+                                                        provider_component,
+                                                        source_key,
+                                                        resolved_output_idx,
+                                                        resolved_input_idx,
+                                                    )
+                                                )
                                     # else: this provider candidate is not eligible --
                                     # either its modeled semantic node didn't match any
                                     # declared source_class, or it does not expose the


### PR DESCRIPTION
Closes #179.

A room served by several VAVs had one AHU branch: only one of its damper controllers drove anything and the room received a fraction of its air (HTR9_VEN02: 12 VAVs, 4 rooms, 4 branches). Calibrating against the per-VAV flow sensors and the AHU's total flow was then impossible -- the model's total is the sum of 4 branch flows where the meter sums 12.

**Shape** (the second option of the issue, chosen after discussion): one AHU branch per VAV, and the zone sums.

* **AHU**: the damper patterns index the branches by VAV (`input_port_index=vavs`). `exhaustTemperature` stays one slot per room -- a room has one exhaust temperature however many branches serve it -- and the AHU maps each exhaust branch to its room's slot from the wiring (`_exhaust_branch_map`: branch *b* belongs to the zone that consumes `supplyAirFlowRate[b]`), in `do_step` and `forward` alike. Hand-built models with as many temperature slots as branches are unchanged (identity map).
* **Zone**: `BuildingSpaceSystem.supplyAirFlowRate` / `exhaustAirFlowRate` are Vector ports on the composite, one slot per branch serving the zone, summed into the submodels' shared scalar port (`do_step`) and the `forward` inputs. A lumped zone only sees the total; every branch keeps its own damper and calibratable nominal flow. The zone pattern binds the room's VAVs as a set and reads each VAV's branch into its own slot; the per-VAV flow sensors read their VAV's branch.
* **Connection model**: a scalar into a Vector port without an index takes slot 0 (so every existing `add_connection(schedule, room, ..., "supplyAirFlowRate")` still works); Vector -> Vector with a slot on one side only puts the other side on slot 0; the same output -> input pair wired again on other slots merges into one connection with tensor slot indices (the Vector -> Vector form both engines already route; the functional slot sources now expand tensor indices per slot); multi-slot indices serialize as lists.
* **Translator**: a set-bound index node that is not the sender yields one candidate edge per element (a zone's VAVs indexing the AHU's branches) instead of collapsing to the first.

**Tests**: `tests/systems/building_space/test_vector_flow_ports.py` (two zones on three branches: merged two-slot connection, branch -> room map `[0, 1, 1]`, the zone sums its branches, object / functional parity); `test_brick14_bms_patterns` now expects one branch per VAV, three drivers, and a two-slot connection for the two-VAV room whose flow sensors read those branches.

On HTR9_VEN02 the translation gives 12 branches with the rooms on slots `[0..3] -> branches 1..4`, `[0..3] -> 5..8`, `0 -> 0`, `[0..2] -> 9..11`, and all 12 flow sensors wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Regression** (translator, systems, simulator, functional estimator, model, optimizer): 496 passed; the only failures are pre-existing on dev -- `test_full_pareto_controls_costs_and_constraints_are_batched` (`assert 1 == 2`), the graphviz `test_visualize` on a machine without pygraphviz, and `test_batched_functional.py` when run in the same pytest process as the translator tests (`'SemanticType' object has no attribute 'uri'`; it passes on its own).

Fused state-space clusters sum a member's Vector air-flow input into its single column, so the wall-coupled examples run unchanged.
