### PR TITLE
fix: visualize() lays out left-to-right by default

### DIFF
--- a/twin4build/model/semantic_model/semantic_model.py
+++ b/twin4build/model/semantic_model/semantic_model.py
@@ -2496,7 +2496,7 @@ class SemanticModel:
         instance_style=None,
         deduplicate_inverse=True,
         pydot_transform=None,
-        rankdir=None,
+        rankdir="LR",
     ):
         """
         Visualize RDF graph with optional class and predicate filtering.
@@ -2544,9 +2544,12 @@ class SemanticModel:
                 (e.g. s4syst:connectedThrough / s4syst:connectsSystem).
             pydot_transform: Optional callable that receives the pydotplus graph
                 object after node styling and can modify it in place before rendering.
-            rankdir: Layout direction passed to Graphviz: ``"TB"`` (default
-                when None), ``"BT"``, ``"LR"`` or ``"RL"``. Wide, shallow
-                graphs are usually far more readable with ``"LR"``.
+            rankdir: Layout direction passed to Graphviz: ``"LR"`` (default),
+                ``"RL"``, ``"TB"`` or ``"BT"``; ``None`` leaves Graphviz's
+                own default (top-to-bottom).  A model graph is a wide,
+                shallow fan-out (one AHU, many zones and sensors): laid out
+                top-to-bottom it becomes a single band thousands of points
+                wide, left-to-right it reads as a flow diagram.
         """
         # Validated up front: styling a large graph is slow, so an unusable
         # value should fail before that work rather than after it.

--- a/twin4build/tests/model/semantic_model/test_semantic_model.py
+++ b/twin4build/tests/model/semantic_model/test_semantic_model.py
@@ -2315,13 +2315,16 @@ class TestSemanticModel(unittest.TestCase):
         self.model.visualize(rankdir="LR")
         self.assertRegex(self._read_object_graph_dot(), r"rankdir\s*=\s*LR")
 
-    def test_visualize_rankdir_defaults_to_unset(self):
-        """Without rankdir the DOT stays as before (Graphviz default TB)."""
+    def test_visualize_rankdir_defaults_to_left_to_right(self):
+        """The default layout is left-to-right; ``None`` leaves Graphviz's
+        own default (top-to-bottom) by not writing rankdir at all."""
         if not self.graphviz_installed:
             self.skipTest("Graphviz drawing backend is not available")
 
         self._setup_visualize_data()
         self.model.visualize()
+        self.assertRegex(self._read_object_graph_dot(), r"rankdir\s*=\s*LR")
+        self.model.visualize(rankdir=None)
         self.assertNotRegex(self._read_object_graph_dot(), r"rankdir\s*=")
 
     def test_visualize_rankdir_rejects_invalid_value(self):


### PR DESCRIPTION
A model graph is a wide, shallow fan-out (one AHU, many zones and sensors). Laid out top-to-bottom -- Graphviz's default, which is what `rankdir=None` gave after #173 / the rankdir exposure -- the HTR9_VEN02 model (93 nodes, 190 edges) came out as a single band 20000 points wide and 1000 tall. Left-to-right it reads as a flow diagram.

`SemanticModel.visualize(rankdir="LR")` is now the default; `None` keeps Graphviz's own default. Test updated: the default DOT carries `rankdir=LR`, `rankdir=None` writes none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)